### PR TITLE
Finalize v0.8.3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,8 +41,8 @@ jobs:
         pip install flake8 ruff pytest
         pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8 and ruff (only on oldest Python version)
-      if: ${{ matrix.python-version == 3.9 }}
+    - name: Lint with flake8 and ruff (only on most recent Python version)
+      if: ${{ matrix.python-version == 3.12 }}
       run: |
         # Stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
@@ -52,8 +52,8 @@ jobs:
       run: |
         pytest
 
-    - name: Run doctests (only on oldest Python version)
-      if: ${{ matrix.python-version == 3.9 }}
+    - name: Run doctests (only on most recent Python version)
+      if: ${{ matrix.python-version == 3.12 }}
       run: |
         pip install recommonmark sphinx
         cd doc

--- a/mass/__init__.py
+++ b/mass/__init__.py
@@ -11,7 +11,7 @@ Joe Fowler, NIST Boulder Labs.  November 2010--
 
 # This is the unique source of truth about the version number (since May 26, 2023)
 # [Recommendation 1 in https://packaging.python.org/en/latest/guides/single-sourcing-package-version/]
-__version__ = "0.8.3pre1"
+__version__ = "0.8.3"
 
 from .core import *
 from .calibration import *


### PR DESCRIPTION
Make doctests and ruff run using _newest_, not _oldest_ Python version.