### PR TITLE
add del data to try to prevent test failures

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -223,7 +223,6 @@ class TestTESGroup:
             # print(results_cython[k])
             # print(results_cython[k]/results_python[k])
             assert results_cython[k] == pytest.approx(results_python[k], rel=0.003)
-        del data
 
     def test_experiment_state(self, tmp_path):
         # First test with the default experimentStateFile
@@ -255,7 +254,6 @@ class TestTESGroup:
             ds.good(state="START")
         nfun = np.sum(ds.good(state="funstate"))
         assert nfun == 252
-        del data
 
     def test_nonoise_data(self, tmp_path):
         """Test behavior of a TESGroup without noise data."""
@@ -270,7 +268,6 @@ class TestTESGroup:
             data.compute_ats_filter()
         data.assume_white_noise()
         data.compute_ats_filter()
-        del data
 
     @staticmethod
     def test_noise_only():
@@ -278,7 +275,6 @@ class TestTESGroup:
         pattern = "tests/regression_test/regress_noise_*.ljh"
         data = mass.TESGroup(pattern, noise_only=True)
         data.compute_noise()
-        del data
 
     def test_all_channels_bad(self, tmp_path):
         """Make sure it isn't an error to load a data set where all channels are marked bad"""
@@ -293,7 +289,6 @@ class TestTESGroup:
         data2.set_chan_good(1)
         LOG.info("Testing printing of a TESGroup")
         LOG.info(data2)
-        del data2
 
     def test_save_hdf5_calibration_storage(self, tmp_path):
         "calibrate a dataset, make sure it saves to hdf5"
@@ -312,7 +307,6 @@ class TestTESGroup:
         # These 2 checks test issue #102.
         assert ds2.peak_samplenumber is not None
         assert ds2.peak_samplenumber == ds.peak_samplenumber
-        del data
 
     def test_make_auto_cuts(self, tmp_path):
         """Make sure that non-trivial auto-cuts are generated and reloadable from file."""
@@ -329,7 +323,6 @@ class TestTESGroup:
         for ds in data2:
             assert ds.saved_auto_cuts.cuts_prm["postpeak_deriv"][1] > 0.
             assert ds.saved_auto_cuts.cuts_prm["pretrigger_rms"][1] > 0.
-        del data
 
     def test_auto_cuts_after_others(self, tmp_path):
         """Make sure that non-trivial auto-cuts are generated even if other cuts are made first.
@@ -346,7 +339,6 @@ class TestTESGroup:
         ngood = ds.good().sum()
         assert ngood < ds.nPulses - arbcut.sum()
         assert ngood > 0
-        del data
 
     def test_plot_filters(self, tmp_path):
         "Check that issue 105 is fixed: data.plot_filters() doesn't fail on 1 channel."
@@ -359,7 +351,6 @@ class TestTESGroup:
         data.compute_noise()
         data.compute_5lag_filter()  # not enough pulses for ats filters
         data.plot_filters()
-        del data
 
     @pytest.mark.filterwarnings("ignore:divide by zero encountered")
     def test_time_drift_correct(self, tmp_path):
@@ -374,7 +365,6 @@ class TestTESGroup:
         data.drift_correct()
         data.phase_correct()
         data.time_drift_correct()
-        del data
 
     @pytest.mark.xfail
     def test_invert_data(self, tmp_path):
@@ -386,7 +376,6 @@ class TestTESGroup:
         ds.invert_data = True
         raw2 = ds.data
         assert np.all(rawinv == raw2)
-        del data
 
     @pytest.mark.filterwarnings("ignore:invalid value encountered")
     def test_issue156(self, tmp_path):
@@ -409,7 +398,6 @@ class TestTESGroup:
             if ds.channum not in data.good_channels:
                 raise ValueError("Failed issue156 test with %d valid bins (lowestbin=%d)" %
                                  (NBINS - lowestbin, lowestbin))
-        del data
 
     @staticmethod
     def test_noncontinuous_noise():
@@ -419,7 +407,6 @@ class TestTESGroup:
         data = mass.TESGroup(src_name, noi_name, noise_is_continuous=False)
         ds = data.channel[1]
         ds.compute_noise()
-        del data
 
     def test_pulse_model_and_ljh2off(self, tmp_path):
         data = self.load_data(hdf5dir=tmp_path)
@@ -473,7 +460,6 @@ class TestTESGroup:
             assert off[7] == off_multi[7]
             assert off[7] == off_multi[N + 7]
             assert off[7] != off_multi[N + 6]
-        del data
 
     def test_ljh_records_to_off(self, tmp_path):
         """Be sure ljh_records_to_off works with ljh files of 2 or more segments."""
@@ -500,7 +486,6 @@ class TestTESGroup:
             off_version = "0.3.0"
             dtype = mass.off.off.recordDtype(off_version, nbasis, descriptive_coefs_names=False)
             mass.ljh2off.ljh_records_to_off(ljhfile, f, projectors, basis, n_ignore_presamples, dtype)
-        del data
 
     @staticmethod
     def test_projectors_script(tmp_path):
@@ -564,7 +549,6 @@ class TestTESGroup:
                 with pytest.raises(ValueError):
                     ds.good(state="A")
             dir.cleanup()
-            del data
 
 
 class TestTESHDF5Only:
@@ -577,14 +561,12 @@ class TestTESHDF5Only:
         noi_name = 'tests/regression_test/regress_noise_chan1.ljh'
         hdf5_file = tempfile.NamedTemporaryFile(suffix='_mass.hdf5')
         hdf5_noisefile = tempfile.NamedTemporaryFile(suffix='_mass_noise.hdf5')
-        data = mass.TESGroup([src_name], [noi_name], hdf5_filename=hdf5_file.name,
-                             hdf5_noisefilename=hdf5_noisefile.name)
+        mass.TESGroup([src_name], [noi_name], hdf5_filename=hdf5_file.name,
+                      hdf5_noisefilename=hdf5_noisefile.name)
 
         data2 = mass.TESGroupHDF5(hdf5_file.name)
         LOG.info("Testing printing of a TESGroupHDF5")
         LOG.info(data2)
-        del data
-        del data2
 
     @staticmethod
     def test_ordering_hdf5only():
@@ -608,4 +590,3 @@ class TestTESHDF5Only:
             data = mass.TESGroupHDF5(fname)
             for i, ds in enumerate(data):
                 assert ds.channum == cnums[i]
-            del data

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -293,7 +293,7 @@ class TestTESGroup:
         data2.set_chan_good(1)
         LOG.info("Testing printing of a TESGroup")
         LOG.info(data2)
-        del data
+        del data2
 
     def test_save_hdf5_calibration_storage(self, tmp_path):
         "calibrate a dataset, make sure it saves to hdf5"

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -503,14 +503,13 @@ class TestTESGroup:
         del data
 
     @staticmethod
-    def test_projectors_script():
+    def test_projectors_script(tmp_path):
 
         class Args:
             def __init__(self):
                 self.pulse_path = os.path.join('tests', 'regression_test', 'regress_chan1.ljh')
                 self.noise_path = os.path.join('tests', 'regression_test', 'regress_noise_chan1.ljh')
-                self.output_path = os.path.join(
-                    'tests', 'regression_test', 'projectors_script_test.hdf5')
+                self.output_path = os.path.join(tmp_path, 'projectors_script_test.hdf5')
                 self.replace_output = True
                 self.max_channels = 4
                 self.n_ignore_presamples = 2
@@ -519,9 +518,8 @@ class TestTESGroup:
                 self.n_basis = 5
                 self.maximum_n_pulses = 4000
                 self.silent = False
-                self.mass_hdf5_path = os.path.join(
-                    'tests', 'regression_test', 'projectors_script_test_mass.hdf5')
-                self.mass_hdf5_noise_path = None
+                self.mass_hdf5_path = os.path.join(tmp_path, 'projectors_script_test_mass.hdf5')
+                self.mass_hdf5_noise_path = os.path.join(tmp_path, 'projectors_script_test_noise_mass.hdf5')
                 self.invert_data = False
                 self.dont_optimize_dp_dt = True
                 self.extra_n_basis_5lag = 1
@@ -530,8 +528,6 @@ class TestTESGroup:
                 self.f_3db_5lag = None
 
         mass.core.projectors_script.main(Args())
-        import gc
-        gc.collect()
 
     @staticmethod
     def test_expt_state_files():
@@ -582,7 +578,7 @@ class TestTESHDF5Only:
         hdf5_file = tempfile.NamedTemporaryFile(suffix='_mass.hdf5')
         hdf5_noisefile = tempfile.NamedTemporaryFile(suffix='_mass_noise.hdf5')
         data = mass.TESGroup([src_name], [noi_name], hdf5_filename=hdf5_file.name,
-                      hdf5_noisefilename=hdf5_noisefile.name)
+                             hdf5_noisefilename=hdf5_noisefile.name)
 
         data2 = mass.TESGroupHDF5(hdf5_file.name)
         LOG.info("Testing printing of a TESGroupHDF5")


### PR DESCRIPTION
We're seeing test failures related to hdf5 files still being open so we can't overwrite them. This is an attempt to fix it by explicitly closing our data objects that have references to hdf5 files, so that they close the hdf5 files. In the projectors script case there is no easy handle to the data object, so I call gc.collect instead.

We should probably re-run the tests on this a few times before merging.

Also it would be "more correct" to use the setup and teardown methods in the test harness to always close the relevant hdf5 files. I didn't want to re-write to use pytest style, or to use add features using the old unittest style. It may also be "more correct" to use temporary directories for each test so they don't try to overwrite each other, Joe objected since that is not standard usage. So `del data` was the remaining solution. 