### PR TITLE
fix #271 and update nist ASD

### DIFF
--- a/doc/hci_lines_from_asd.rst
+++ b/doc/hci_lines_from_asd.rst
@@ -55,8 +55,8 @@ a commonly injected gas at the NIST EBIT.
 
 .. testoutput::
 
-  ['Sn', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Rb', 'Se', 'Cl', 'Br']
-  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  ['Sn', 'Cu', 'Na', 'As', 'Zn', 'Ne', 'Ge', 'Ga', 'Rb', 'Se']
+  [9, 1, 2, 3, 4, 5, 6, 7, 8, 10]
   {'1s 2S J=1/2': 0.0, '2p 2P* J=1/2': 1021.5, '2s 2S J=1/2': 1021.5, '2p 2P* J=3/2': 1022.0, '3p 2P* J=1/2': 1210.8, '3s 2S J=1/2': 1210.8}
   1021.5
 
@@ -132,6 +132,6 @@ and then add some of the lower order H- and He-like Ga lines.
 .. testoutput::
 
   [SpectralLine: Ne10 2p 2P* J=3/2, 1022.0]
-  [SpectralLine: O7 1s.2p 1P* J=1, 573.9]
+  [SpectralLine: O7 1s.2p 1P* J=1, 574.0]
   [[SpectralLine: Ga31 2p 2P* J=1/2, 9917.0], [SpectralLine: Ga31 2s 2S J=1/2, 9918.0], [SpectralLine: Ga31 2p 2P* J=3/2, 9960.3], [SpectralLine: Ga31 3p 2P* J=1/2, 11767.7], [SpectralLine: Ga31 3s 2S J=1/2, 11768.0], [SpectralLine: Ga31 3d 2D J=3/2, 11780.5]]
-  [[SpectralLine: Ga30 1s.2s 3S J=1, 9535.8], [SpectralLine: Ga30 1s.2p 3P* J=0, 9571.9], [SpectralLine: Ga30 1s.2p 3P* J=1, 9574.6], [SpectralLine: Ga30 1s.2s 1S J=0, 9574.8], [SpectralLine: Ga30 1s.2p 3P* J=2, 9607.5], [SpectralLine: Ga30 1s.2p 1P* J=1, 9628.3], [SpectralLine: Ga30 1s.3s 3S J=1, 11304.6]]
+  [[SpectralLine: Ga30 1s.2s 3S J=1, 9535.6], [SpectralLine: Ga30 1s.2p 3P* J=0, 9571.8], [SpectralLine: Ga30 1s.2p 3P* J=1, 9574.4], [SpectralLine: Ga30 1s.2s 1S J=0, 9574.6], [SpectralLine: Ga30 1s.2p 3P* J=2, 9607.4], [SpectralLine: Ga30 1s.2p 1P* J=1, 9628.2], [SpectralLine: Ga30 1s.3s 3S J=1, 11304.6]]

--- a/mass/calibration/hci_lines.py
+++ b/mass/calibration/hci_lines.py
@@ -18,7 +18,7 @@ from . import LORENTZIAN_PEAK_HEIGHT
 import xraydb
 
 INVCM_TO_EV = sp_const.c * sp_const.physical_constants['Planck constant in eV s'][0] * 100.0
-DEFAULT_PICKLE_NAME = 'nist_asd.pickle'
+DEFAULT_PICKLE_NAME = 'nist_asd_2023.pickle'
 
 
 class NIST_ASD:

--- a/mass/off/experiment_state.py
+++ b/mass/off/experiment_state.py
@@ -114,8 +114,13 @@ class ExperimentStateFile:
             assert i0_allLabels > 0
             for k in statesDict.keys():
                 last_key = k
-            s = statesDict[last_key]
-            s2 = slice(s.start, i0_unixnanos + len(unixnanos))  # set the slice from the start of the state to the last new record
+                s = statesDict[last_key]
+            if isinstance(s, slice):
+                s2 = slice(s.start, i0_unixnanos+len(unixnanos))  # set the slice from the start of the state to the last new record
+            if isinstance(s, list):
+                s_ = s[-1] # get last instance of same state
+                s[-1] = slice(s_.start, i0_unixnanos+len(unixnanos))  # set the slice from the start of the state to the last new record
+                s2 = s    
             statesDict[k] = s2
             return statesDict
 

--- a/tests/off/test_channels.py
+++ b/tests/off/test_channels.py
@@ -9,7 +9,7 @@ import numpy as np
 import pylab as plt
 import lmfit
 import h5py
-# import resource
+import resource
 import tempfile
 
 # Remove a warning message
@@ -549,34 +549,34 @@ def test_save_load_recipe_book(tmp_path):
     assert rb.craft("energy", args) == rb2.craft("energy", args)
 
 
-# def test_open_many_OFF_files():
-#     """Open more OFF ChannelGroup objects than the system allows. Test that close method closes them."""
+def test_open_many_OFF_files():
+    """Open more OFF ChannelGroup objects than the system allows. Test that close method closes them."""
 
-#     # LOWER the system's limit on number of open files, to make the test smaller
-#     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-#     request_maxfiles = min(60, soft_limit)
-#     resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
-#     try:
-#         maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-#         NFilesToOpen = maxfiles // 2 + 10
+    # LOWER the system's limit on number of open files, to make the test smaller
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    request_maxfiles = min(60, soft_limit)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
+    try:
+        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        NFilesToOpen = maxfiles // 2 + 10
 
-#         filename = os.path.join(d, "data_for_test", "20181205_BCDEFGHI/20181205_BCDEFGHI_chan1.off")
-#         filelist = getOffFileListFromOneFile(filename, maxChans=2)
-#         for _ in range(NFilesToOpen):
-#             _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
-#                              excludeStates=["START", "END"])
+        filename = os.path.join(d, "data_for_test", "20181205_BCDEFGHI/20181205_BCDEFGHI_chan1.off")
+        filelist = getOffFileListFromOneFile(filename, maxChans=2)
+        for _ in range(NFilesToOpen):
+            _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
+                             excludeStates=["START", "END"])
 
-#         # Now open one ChannelGroup with too many files. If the resources aren't freed, we can
-#         # only open it once, not twice.
-#         NFilePairsToOpen = (maxfiles - 12) // 6
-#         filelist *= NFilePairsToOpen
-#         for _ in range(3):
-#             _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
-#                              excludeStates=["START", "END"])
+        # Now open one ChannelGroup with too many files. If the resources aren't freed, we can
+        # only open it once, not twice.
+        NFilePairsToOpen = (maxfiles - 12) // 6
+        filelist *= NFilePairsToOpen
+        for _ in range(3):
+            _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
+                             excludeStates=["START", "END"])
 
-#     # Use the try...finally to undo our reduction in the limit on number of open files.
-#     finally:
-#         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+    # Use the try...finally to undo our reduction in the limit on number of open files.
+    finally:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
 def test_listmode_to_hdf5():

--- a/tests/off/test_channels.py
+++ b/tests/off/test_channels.py
@@ -9,7 +9,7 @@ import numpy as np
 import pylab as plt
 import lmfit
 import h5py
-import resource
+# import resource
 import tempfile
 
 # Remove a warning message
@@ -452,7 +452,7 @@ def test_duplicate_cuts():
     data.cutAdd("deliberateduplicate", lambda energy: energy < 750, overwrite=True)
 
 
-def test_recipes():
+def test_recipes(tmp_path):
     rb = util.RecipeBook(baseIngredients=["x", "y", "z"], propertyClass=None,
                          coefs_dtype=None)
 
@@ -478,13 +478,13 @@ def test_recipes():
     assert rb._craftWithFunction(lambda a, b, c: a + b + c, args) == 18
     assert rb.craft(lambda a, b, c: a + b + c, args) == 18
 
-    with tempfile.NamedTemporaryFile(suffix=".rbpkl") as pklfile:
-        rb.to_file(pklfile.name, overwrite=True)
-        rb2 = util.RecipeBook.from_file(pklfile.name)
+    save_path = tmp_path / "recipe_book.pkl"
+    rb.to_file(save_path)
+    rb2 = util.RecipeBook.from_file(save_path)
 
-        assert rb2.craft("a", args) == 3
-        assert rb2.craft("b", args) == 6
-        assert rb2.craft("c", args) == 9
+    assert rb2.craft("a", args) == 3
+    assert rb2.craft("b", args) == 6
+    assert rb2.craft("c", args) == 9
 
 
 def test_linefit_has_tail_and_has_linear_background():
@@ -538,46 +538,45 @@ def test_iterstates():
         ds.plotHist(np.arange(100, 2500, 50), 'energy', states="BC", coAddStates=False)
 
 
-def test_save_load_recipe_book():
+def test_save_load_recipe_book(tmp_path):
     rb = ds.recipes
-    with tempfile.NamedTemporaryFile(suffix=".rbpkl") as rbfile:
-        save_path = rbfile.name
-        rb.to_file(save_path, overwrite=True)
-        rb2 = util.RecipeBook.from_file(save_path)
-        assert rb.craftedIngredients.keys() == rb2.craftedIngredients.keys()
-        args = {"pretriggerMean": 1, "filtValue": 2}
-        print(rb.craftedIngredients["energy"])
-        assert rb.craft("energy", args) == rb2.craft("energy", args)
+    save_path = tmp_path / "recipe_book.pkl"
+    rb.to_file(save_path)
+    rb2 = util.RecipeBook.from_file(save_path)
+    assert rb.craftedIngredients.keys() == rb2.craftedIngredients.keys()
+    args = {"pretriggerMean": 1, "filtValue": 2}
+    print(rb.craftedIngredients["energy"])
+    assert rb.craft("energy", args) == rb2.craft("energy", args)
 
 
-def test_open_many_OFF_files():
-    """Open more OFF ChannelGroup objects than the system allows. Test that close method closes them."""
+# def test_open_many_OFF_files():
+#     """Open more OFF ChannelGroup objects than the system allows. Test that close method closes them."""
 
-    # LOWER the system's limit on number of open files, to make the test smaller
-    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    request_maxfiles = min(60, soft_limit)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
-    try:
-        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-        NFilesToOpen = maxfiles // 2 + 10
+#     # LOWER the system's limit on number of open files, to make the test smaller
+#     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+#     request_maxfiles = min(60, soft_limit)
+#     resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
+#     try:
+#         maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+#         NFilesToOpen = maxfiles // 2 + 10
 
-        filename = os.path.join(d, "data_for_test", "20181205_BCDEFGHI/20181205_BCDEFGHI_chan1.off")
-        filelist = getOffFileListFromOneFile(filename, maxChans=2)
-        for _ in range(NFilesToOpen):
-            _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
-                             excludeStates=["START", "END"])
+#         filename = os.path.join(d, "data_for_test", "20181205_BCDEFGHI/20181205_BCDEFGHI_chan1.off")
+#         filelist = getOffFileListFromOneFile(filename, maxChans=2)
+#         for _ in range(NFilesToOpen):
+#             _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
+#                              excludeStates=["START", "END"])
 
-        # Now open one ChannelGroup with too many files. If the resources aren't freed, we can
-        # only open it once, not twice.
-        NFilePairsToOpen = (maxfiles - 12) // 6
-        filelist *= NFilePairsToOpen
-        for _ in range(3):
-            _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
-                             excludeStates=["START", "END"])
+#         # Now open one ChannelGroup with too many files. If the resources aren't freed, we can
+#         # only open it once, not twice.
+#         NFilePairsToOpen = (maxfiles - 12) // 6
+#         filelist *= NFilePairsToOpen
+#         for _ in range(3):
+#             _ = ChannelGroup(filelist, verbose=True, channelClass=Channel,
+#                              excludeStates=["START", "END"])
 
-    # Use the try...finally to undo our reduction in the limit on number of open files.
-    finally:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+#     # Use the try...finally to undo our reduction in the limit on number of open files.
+#     finally:
+#         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
 def test_listmode_to_hdf5():

--- a/tests/off/test_off.py
+++ b/tests/off/test_off.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import mass.off
 from mass.off import OffFile
-import resource
+# import resource
 
 d = os.path.dirname(os.path.realpath(__file__))
 
@@ -30,28 +30,28 @@ def test_open_file_with_base64_projectors_and_basis():
     assert OffFile(filename) is not None
 
 
-def test_mmap_many_files():
-    """Open more OFF file objects than the system allows. Test that close method closes them."""
-    files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
+# def test_mmap_many_files():
+#     """Open more OFF file objects than the system allows. Test that close method closes them."""
+#     files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
 
-    # LOWER the system's limit on number of open files, to make the test smaller
-    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    request_maxfiles = min(30, soft_limit)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
-    try:
-        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-        NFilesToOpen = maxfiles // 3 + 10
+#     # LOWER the system's limit on number of open files, to make the test smaller
+#     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+#     request_maxfiles = min(30, soft_limit)
+#     resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
+#     try:
+#         maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+#         NFilesToOpen = maxfiles // 3 + 10
 
-        filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
-        for _ in range(NFilesToOpen):
-            f = OffFile(filename)
-            assert f.nRecords > 0
-            files.append(f)
-            f.close()
+#         filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
+#         for _ in range(NFilesToOpen):
+#             f = OffFile(filename)
+#             assert f.nRecords > 0
+#             files.append(f)
+#             f.close()
 
-    # Use the try...finally to ensure that the gc can close files at the end of this test,
-    # preventing a cascade of meaningless test failures if this one fails.
-    # Also undo our reduction in the limit on number of open files.
-    finally:
-        del files
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+#     # Use the try...finally to ensure that the gc can close files at the end of this test,
+#     # preventing a cascade of meaningless test failures if this one fails.
+#     # Also undo our reduction in the limit on number of open files.
+#     finally:
+#         del files
+#         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))

--- a/tests/off/test_off.py
+++ b/tests/off/test_off.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import mass.off
 from mass.off import OffFile
-# import resource
+import resource
 
 d = os.path.dirname(os.path.realpath(__file__))
 
@@ -30,28 +30,28 @@ def test_open_file_with_base64_projectors_and_basis():
     assert OffFile(filename) is not None
 
 
-# def test_mmap_many_files():
-#     """Open more OFF file objects than the system allows. Test that close method closes them."""
-#     files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
+def test_mmap_many_files():
+    """Open more OFF file objects than the system allows. Test that close method closes them."""
+    files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
 
-#     # LOWER the system's limit on number of open files, to make the test smaller
-#     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-#     request_maxfiles = min(30, soft_limit)
-#     resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
-#     try:
-#         maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-#         NFilesToOpen = maxfiles // 3 + 10
+    # LOWER the system's limit on number of open files, to make the test smaller
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    request_maxfiles = min(30, soft_limit)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
+    try:
+        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        NFilesToOpen = maxfiles // 3 + 10
 
-#         filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
-#         for _ in range(NFilesToOpen):
-#             f = OffFile(filename)
-#             assert f.nRecords > 0
-#             files.append(f)
-#             f.close()
+        filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
+        for _ in range(NFilesToOpen):
+            f = OffFile(filename)
+            assert f.nRecords > 0
+            files.append(f)
+            f.close()
 
-#     # Use the try...finally to ensure that the gc can close files at the end of this test,
-#     # preventing a cascade of meaningless test failures if this one fails.
-#     # Also undo our reduction in the limit on number of open files.
-#     finally:
-#         del files
-#         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+    # Use the try...finally to ensure that the gc can close files at the end of this test,
+    # preventing a cascade of meaningless test failures if this one fails.
+    # Also undo our reduction in the limit on number of open files.
+    finally:
+        del files
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))


### PR DESCRIPTION
1. fixes #271 by handling states that are lists of slices
2. updates the `nist_asd.pickle` with newer `nist_asd_2023.pickle`. Apparently the ASD is updated once a year, and grant got the latest version. It actually has some changes that are large enough to change the output in doctests, so I also updated the doc tests. I renamed the original to `nist_asd_2019.pickle` since deleting it doesn't actually make the repo any smaller.
3. use `tmp_path` instead of wrong uses of `tempfile` API for two more tests
~~4. (I'll revert this in my next PR) comment out the tests that use resources so I can run tests on windows~~