### PR TITLE
add upper limit on numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,3 @@ mass = [
 
 [tool.setuptools_scm]
 version_file = "mass/_version.py"
-# just want to run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,4 @@ mass = [
 
 [tool.setuptools_scm]
 version_file = "mass/_version.py"
+# just want to run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "indexedproperty",
     "lmfit>=0.9.11",
     "matplotlib>1.5",
-    "numpy>=1.14",
+    "numpy>=1.14,<2.0",
     "packaging",
     "palettable",
     "pandas",


### PR DESCRIPTION
numpy 2.0 was released, and breaks at least one test. lets add an upper limit for now until someone has time to figure out what is different.