### PR TITLE
Fix plot noise

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,7 @@
 * Fix problem where numpy 2.0 was failing a regression test. Not a true regression, so we broaden the acceptance criteria (issue 295).
 * Add installation instructions to README for https-based installation, in addition to ssh-based.
 * Fix Ruff errors.
+* Allow setting channels bad when in noise-only mode (issue 301).
 
 **0.8.4** June 5, 2024
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@
 * Add installation instructions to README for https-based installation, in addition to ssh-based.
 * Fix Ruff errors.
 * Allow setting channels bad when in noise-only mode (issue 301).
+* Make `plot_noise()` have the right x-axis (frequency) values (issue 303).
 
 **0.8.4** June 5, 2024
 

--- a/mass/core/channel_group.py
+++ b/mass/core/channel_group.py
@@ -199,6 +199,7 @@ class TESGroup(CutFieldMixin, GroupLooper):  # noqa: PLR0904, PLR0917
                 self.hdf5_noisefile = h5py.File(hdf5_noisefilename, 'w')
             if noise_only:
                 self.n_channels = len(self.noise_filenames)
+                self.hdf5_file = self.hdf5_noisefile
 
         # Load up experiment state file
         self.experimentStateFile = None

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -547,6 +547,14 @@ class TestTESGroup:
                     ds.good(state="A")
 
 
+def test_noiseonly():
+    """Check that you can set a channel bad in a noise-only TESGroup.
+    This tests for issue #301."""
+    noi_name = 'tests/regression_test/regress_noise_chan1.ljh'
+    data = mass.TESGroup(noi_name, noise_only=True)
+    data.set_chan_bad(1, "Just testing stuff")
+
+
 class TestTESHDF5Only:
     """Basic tests of the TESGroup object when we use the HDF5-only variant."""
 


### PR DESCRIPTION
There seems to be a bug in the x-axis on `TESGroup.plot_noise(...)` that was shifting all values to the left by one `delta_f`, or by **1/record length**. Not sure why it's like that, but this fixes.

Also adds the option to ask for the DC level to appear on plot (but it's absent by default).