### PR TITLE
Fix optimal filters' VdV and variance calculations

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@
 * Add `EnergyCalibration.ismonotonic()` and test it (issue 305).
 * Fix errors when an experiment state appears 2+ times, as "PAUSE" often does (issue 309).
 * Start testing on Python 3.13 (was 3.12) and oldest valid version: 3.9.
+* Fix errors in the computation of V/dV and estimated variance for optimal filters (issue 307).
 
 **0.8.4** June 5, 2024
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,7 @@
 * Make `plot_noise()` have the right x-axis (frequency) values (issue 303).
 * Add `EnergyCalibration.ismonotonic()` and test it (issue 305).
 * Fix errors when an experiment state appears 2+ times, as "PAUSE" often does (issue 309).
+* Start testing on Python 3.13 (was 3.12) and oldest valid version: 3.9.
 
 **0.8.4** June 5, 2024
 

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1185,7 +1185,7 @@ class MicrocalDataSet:  # noqa: PLR0904
             spectrum = self.noise_spectrum.spectrum()
         except Exception:
             spectrum = self.noise_psd[:]
-        avg_signal = np.array(self.average_pulse)
+        avg_signal = self.average_pulse[:]
         if np.sum(np.abs(self.average_pulse)) == 0:
             raise Exception("average pulse is all zeros, try avg_pulses_auto_masks first")
         f = mass.core.Filter(avg_signal, self.nPresamples - self.pretrigger_ignore_samples,

--- a/tests/core/test_filtering.py
+++ b/tests/core/test_filtering.py
@@ -35,7 +35,6 @@ def process_file(prefix, cuts, do_filter=True):
         data.summarize_filters(std_energy=600)
         data.filter_data()
         data.drift_correct(forceNew=True)
-
         data.filter_data(forceNew=True, use_cython=True)
 
     return data
@@ -74,12 +73,12 @@ class TestFilters:
     @staticmethod
     def verify_filters(data, filter_type):
         "Check that the filters contain what we expect"
-        expected = {"ats": 461.57, "5lag": 456.7}[filter_type]
+        expected = {"ats": 458.5, "5lag": 456.7}[filter_type]
         for ds in data:
             f = ds.filter
             assert "noconst" in f.variances
             assert "noconst" in f.predicted_v_over_dv
-            assert f.variances["noconst"] == pytest.approx(8.46e-7, abs=3e-8)
+            assert f.variances["noconst"] == pytest.approx(155.1, abs=0.2)
             assert f.predicted_v_over_dv["noconst"] == pytest.approx(expected, abs=0.3)
 
     def test_vdv_5lag_filters(self):


### PR DESCRIPTION
Use the `OptimalFilter.bracketR(f, noise_autocorrelation)` method to predict filter variance--more reliable than counting on filter computation internals to be correct.
Fixes #307.