### PR TITLE
Remove superfluous deps; use pyproject dependency groups

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,6 +57,7 @@ jobs:
       if: ${{ matrix.python-version == 3.13 }}
       run: |
         uv sync --all-extras --group docs
+        which sphinx-build
         cd doc
         make clean
         make doctest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,11 +44,11 @@ jobs:
 
     - name: Lint with flake8 and ruff (only on most recent Python version)
       # Run ruff, but don't fail tests regarless of result.
-      # Stop the build if there are Python syntax errors or undefined names, as found by flake8.
+      # (DISABLED Jan 2025) Stop the build if there are Python syntax errors or undefined names, as found by flake8.
       if: ${{ matrix.python-version == 3.13 }}
       run: |
         ruff check --preview || ruff check --preview --statistics --exit-zero
-        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
 
     - name: Test with pytest
       run: pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,18 +28,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'  # cache pip dependencies
+        enable-cache: true
+
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Install the project
+      run: uv sync --all-extras --dev
+
     - name: Lint with flake8 and ruff (only on most recent Python version)
       if: ${{ matrix.python-version == 3.13 }}
       run: |
@@ -54,7 +55,7 @@ jobs:
     - name: Run doctests (only on most recent Python version)
       if: ${{ matrix.python-version == 3.13 }}
       run: |
-        pip install recommonmark sphinx
+        uv sync --all-extras
         cd doc
         make clean
         make doctest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -48,7 +48,7 @@ jobs:
       if: ${{ matrix.python-version == 3.13 }}
       run: |
         ruff check --preview || ruff check --preview --statistics --exit-zero
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
+        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
 
     - name: Test with pytest
       run: pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # - python-version: 3.9
+        - python-version: 3.9
         - python-version: 3.13
 
     steps:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: 3.9
+        # - python-version: 3.9
         - python-version: 3.13
 
     steps:
@@ -43,12 +43,12 @@ jobs:
       run: uv sync --all-extras --dev
 
     - name: Lint with flake8 and ruff (only on most recent Python version)
+      # Run ruff, but don't fail tests regarless of result.
+      # Stop the build if there are Python syntax errors or undefined names, as found by flake8.
       if: ${{ matrix.python-version == 3.13 }}
       run: |
-        # Stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
-        # Run ruff, but don't fail tests regarless of result.
         ruff check --preview || ruff check --preview --statistics --exit-zero
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
 
     - name: Test with pytest
       run: pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,6 +58,7 @@ jobs:
       run: |
         uv sync --all-extras --group docs
         which sphinx-build
+        export PATH=$PATH:`which sphinx-build`
         cd doc
         make clean
         make doctest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,11 +57,9 @@ jobs:
       if: ${{ matrix.python-version == 3.13 }}
       run: |
         uv sync --all-extras --group docs
-        which sphinx-build
-        export PATH=$PATH:`which sphinx-build`
         cd doc
-        make clean
-        make doctest
+        uv run make clean
+        uv run make doctest
 
 # TO DO: generate docs automatically and deploy them.
 #

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,7 +33,8 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
-        enable-cache: true
+        # Cache wasn't working. Need a better understanding before we turn this on:
+        # enable-cache: true
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
@@ -48,14 +49,14 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --extend-exclude nonstandard
         # Run ruff, but don't fail tests regarless of result.
         ruff check --preview || ruff check --preview --statistics --exit-zero
+
     - name: Test with pytest
-      run: |
-        pytest
+      run: pytest
 
     - name: Run doctests (only on most recent Python version)
       if: ${{ matrix.python-version == 3.13 }}
       run: |
-        uv sync --all-extras
+        uv sync --all-extras --group docs
         cd doc
         make clean
         make doctest

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 ## Note on version numbers of Mass
 
+**0.8.7** January 9, 2025-
+
+* Remove some dependencies in `pyproject.toml` that are no longer required.
+
 **0.8.6** December 19, 2024
 
 * Completely refactor filter code to use modern Python and MASS practices, and less spaghetti (issue 312).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,7 +3,7 @@
 **0.8.7** January 9, 2025-
 
 * Remove some dependencies in `pyproject.toml` that are no longer required.
-* Use `uv` to install requirements within GitHub Actions.
+* Use `uv` to install requirements within GitHub Actions. Disable `flake8` linting test, which is broken somehow.
 
 **0.8.6** December 19, 2024
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,6 +3,7 @@
 **0.8.7** January 9, 2025-
 
 * Remove some dependencies in `pyproject.toml` that are no longer required.
+* Use `uv` to install requirements within GitHub Actions.
 
 **0.8.6** December 19, 2024
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,18 +8,13 @@ SPHINXPROJ    = mass
 SOURCEDIR     = .
 BUILDDIR      = _build
 
-# Workaround!
-# It appears sphinx generates scripts with relative #! strings that get confused
-# easily. Try to coerce them to do the right thing
-REALSPHINXBUILD := python $(shell which $(SPHINXBUILD))
-
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(REALSPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(REALSPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,13 +8,18 @@ SPHINXPROJ    = mass
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+# Workaround!
+# It appears sphinx generates scripts with relative #! strings that get confused
+# easily. Try to coerce them to do the right thing
+REALSPHINXBUILD := python $(shell which $(SPHINXBUILD))
+
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(REALSPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(REALSPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,13 @@ dependencies = [
 ]
 
 [dependency-groups]
+# Use `uv sync --dev` to get the development packages
 dev = [
     "pytest",
     "ruff",
     "flake8",
 ]
+# Use `uv sync --group docs` to get the packages needed to create documentation
 docs = [
     "sphinx",
     "recommonmark",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,17 @@ dependencies = [
     # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with .1 or .3. Weird, but remember it!
     "uncertainties",
     "xraydb",
+]
 
-    # The following are for testing only, but until PEP 735 is accepted, there's not an obvious way
-    # to separate them from run dependencies. So for the time being (July 2024), we'll just plain
-    # require them for all users.
+[dependency-groups]
+tests = [
     "pytest",
-    "sphinx",
-    "recommonmark",
     "ruff",
     "flake8",
+]
+docs = [
+    "sphinx",
+    "recommonmark",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,18 +24,18 @@ dependencies = [
     "progress",
     "scikit-learn",
     "scipy>=0.19, !=1.11.2",
-    # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with .1 or .3. Weird, but remember it!
+    # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with 1.11.1 and 1.11.3. Weird, but remember it!
     "uncertainties",
     "xraydb",
-# ]
+]
 
-# [dependency-groups]
-# dev = [
+[dependency-groups]
+dev = [
     "pytest",
     "ruff",
     "flake8",
-# ]
-# docs = [
+]
+docs = [
     "sphinx",
     "recommonmark",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
     {name = "Galen O'Neil", email = "ggggggggg@github.com"},
 ]
 dependencies = [
-    "cycler",
     "deprecation",
     "dill",
     "fastdtw",
@@ -17,15 +16,12 @@ dependencies = [
     "matplotlib>1.5",
     "numpy>=1.14",
     "packaging",
-    "palettable",
-    "pandas",
     "progress",
-    "scikit-learn",
     "scipy>=0.19, !=1.11.2",
     # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with .1 or .3. Weird, but remember it!
-    "statsmodels>0.8",
     "uncertainties",
     "xraydb",
+
     # The following are for testing only, but until PEP 735 is accepted, there's not an obvious way
     # to separate them from run dependencies. So for the time being (July 2024), we'll just plain
     # require them for all users.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,11 @@ authors = [
     {name = "Joe Fowler", email = "drjoefowler@gmail.com"},
     {name = "Galen O'Neil", email = "ggggggggg@github.com"},
 ]
+
+requires-python = ">=3.8"
+readme = "README.md"
+license = {text = "MIT"}
+
 dependencies = [
     "deprecation",
     "dill",
@@ -17,6 +22,7 @@ dependencies = [
     "numpy>=1.14",
     "packaging",
     "progress",
+    "scikit-learn",
     "scipy>=0.19, !=1.11.2",
     # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with .1 or .3. Weird, but remember it!
     "uncertainties",
@@ -31,11 +37,6 @@ dependencies = [
     "ruff",
     "flake8",
 ]
-
-requires-python = ">=3.8"
-readme = "README.md"
-license = {text = "MIT"}
-
 
 [project.urls]
 Repository = "https://github.com/usnistgov/mass.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,15 @@ dependencies = [
     # Bitbucket pipeline tests failed with scipy-1.11.2 but passed with .1 or .3. Weird, but remember it!
     "uncertainties",
     "xraydb",
-]
+# ]
 
-[dependency-groups]
-tests = [
+# [dependency-groups]
+# dev = [
     "pytest",
     "ruff",
     "flake8",
-]
-docs = [
+# ]
+# docs = [
     "sphinx",
     "recommonmark",
 ]


### PR DESCRIPTION
- Use PEP-735 `dependency-groups` to separate core dependencies from those needed only for development (e.g. `pytest`) or for documentation (e.g. `sphinx`). 
- Also, use `uv` to install dependencies inside GitHub Actions.