### PR TITLE
Refactor calibration code

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 
 * Remove some dependencies in `pyproject.toml` that are no longer required.
 * Use `uv` to install requirements within GitHub Actions. Disable `flake8` linting test, which is broken somehow.
+* Refactor energy-calibration code to use modern Python and MASS practices, and less spaghetti (issue 317).
 
 **0.8.6** December 19, 2024
 

--- a/doc/gamma.rst
+++ b/doc/gamma.rst
@@ -331,8 +331,8 @@ Fit for energy resolution with and without drift correction at the 80 keV line.
     	20181018_144520 chan3  Ho166m_80 fwhm=60 ± 1.9
     	20181018_144520 chan13 Ho166m_80 fwhm=62 ± 2.1
     energyNoDC:
-    	20181018_144520 chan3  Ho166m_80 fwhm=64 ± 2.3
-    	20181018_144520 chan13 Ho166m_80 fwhm=70 ± 2.6
+    	20181018_144520 chan3  Ho166m_80 fwhm=65 ± 1.9
+    	20181018_144520 chan13 Ho166m_80 fwhm=71 ± 2.2
 
 OFF vs Plain Comparision
 ------------------------

--- a/mass/calibration/algorithms.py
+++ b/mass/calibration/algorithms.py
@@ -246,21 +246,13 @@ def singlefit(ph, name, lo, hi, binsize_ph, approx_dP_dE):
 
 
 class EnergyCalibrationAutocal:
-    def __init__(self, calibration, ph=None, line_names=None):
+    def __init__(self, ph=None, line_names=None):
         """
         Args:
             line_names (list[str]): names of calibration lines. Names doesn't need to be
             ordered in their energies.
         """
-        if not isinstance(calibration, EnergyCalibration):
-            raise ValueError("EnergyCalibrationAutocal requires an EnergyCalibration calibration.")
-        self.calibration = calibration
-        # store a reference to EnergyCalibrationAutocal in self.calibration
-        # because we want to be able to run diagnose, and examine fits later, even though
-        # normally only self.calibration is stored later in mass
-        # this isn't the best API, but I was able to add it without changing any APIs so nothing breaks
-        self.calibration.autocal = self
-        self.calibration.diagnose = self.diagnose
+        self.cal_factory = mass.EnergyCalibrationMaker.init()
         self.results = None
         self.energy_resolutions = None
         self.line_names = line_names
@@ -294,9 +286,7 @@ class EnergyCalibrationAutocal:
         else:
             self.binsize_ev = [binsize_ev] * len(self.energies_opt)
 
-        z = np.zeros_like(self.ph_opt)
-        names = ["dummy"] * len(z)
-        approx_cal = mass.EnergyCalibrationMaker(self.ph_opt, self.energies_opt, z, z, names).make_calibration()
+        approx_cal = mass.EnergyCalibrationMaker.init(self.ph_opt, self.energies_opt).make_calibration()
         self.fit_range_ev = fit_range_ev
 
         #  Default fit range width is 100 eV for each line.
@@ -312,22 +302,19 @@ class EnergyCalibrationAutocal:
         mresult = multifit(self.ph, self.line_names, self.fit_lo_hi,
                            self.binsize_ev, self.slopes_de_dph, hide_deprecation=self._hide_deprecation)
 
-        for ph, e, n in zip(mresult["peak_ph"], mresult["energies"], mresult['line_names']):
-            self.calibration.add_cal_point(ph, e, name=str(n))
-
+        self.cal_factory = mass.EnergyCalibrationMaker.init(
+            mresult["peak_ph"], mresult["energies"], names=mresult['line_names'])
         self.results = mresult["results"]
         self.energy_resolutions = mresult["eres"]
         self.line_names = mresult["line_names"]
 
-        return self.calibration
+        return self.cal_factory
 
     def autocal(self, smoothing_res_ph=20, fit_range_ev=200.0, binsize_ev=1.0,
                 nextra=2, nincrement=3, nextramax=8, maxacc=0.015):
         self.guess_fit_params(smoothing_res_ph, fit_range_ev, binsize_ev, nextra, nincrement,
                               nextramax, maxacc)
-        self.fit_lines()
-
-        return self.calibration
+        return self.fit_lines()
 
     @property
     def anyfailed(self):
@@ -368,8 +355,8 @@ class EnergyCalibrationAutocal:
 
         ax = fig.add_axes([lm + w, bm, (1.0 - lm - w) - 0.06, h - 0.05])
 
-        for el, pht, energy in zip(self.line_names, self.calibration.cal_point_phs,
-                                   self.calibration.cal_point_energies):
+        for el, pht, energy in zip(self.line_names, self.cal_factory.ph,
+                                   self.cal_factory.energy):
             peak_name = 'Unknown'
             if isstr(el):
                 peak_name = el.replace('Alpha', r'$_{\alpha}$').replace('Beta', r'$_{\beta}$')
@@ -381,15 +368,16 @@ class EnergyCalibrationAutocal:
                     transform=ax.transData + mtrans.ScaledTranslation(5.0 / 72, -12.0 / 72,
                                                                       fig.dpi_scale_trans))
 
-        ax.scatter(self.calibration.cal_point_phs,
-                   self.calibration.cal_point_energies, s=36, c="#3333cc")
+        ax.scatter(self.cal_factory.ph,
+                   self.cal_factory.energy, s=36, c="#3333cc")
 
-        lb = np.amin(self.calibration.cal_point_phs)
-        ub = np.amax(self.calibration.cal_point_phs)
+        lb = np.amin(self.cal_factory.ph)
+        ub = np.amax(self.cal_factory.ph)
 
         width = ub - lb
         x = np.linspace(lb - width / 10, ub + width / 10, 101)
-        y = self.calibration(x)
+        cal = self.cal_factory.make_calibration()
+        y = cal(x)
         ax.plot(x, y, '--', color='orange', lw=2, zorder=-2)
 
         ax.yaxis.set_tick_params(labelleft=False, labelright=True)

--- a/mass/calibration/algorithms.py
+++ b/mass/calibration/algorithms.py
@@ -17,7 +17,6 @@ from matplotlib.ticker import MaxNLocator
 from ..common import isstr
 from mass.calibration.energy_calibration import STANDARD_FEATURES
 import mass.calibration
-from .energy_calibration import EnergyCalibration
 
 
 def line_names_and_energies(line_names):

--- a/mass/calibration/algorithms.py
+++ b/mass/calibration/algorithms.py
@@ -294,9 +294,9 @@ class EnergyCalibrationAutocal:
         else:
             self.binsize_ev = [binsize_ev] * len(self.energies_opt)
 
-        approx_cal = mass.energy_calibration.EnergyCalibration(1, approximate=False)
-        for ph, e in zip(self.ph_opt, self.energies_opt):
-            approx_cal.add_cal_point(ph, e)
+        z = np.zeros_like(self.ph_opt)
+        names = ["dummy"] * len(z)
+        approx_cal = mass.EnergyCalibrationMaker(self.ph_opt, self.energies_opt, z, z, names).make_calibration()
         self.fit_range_ev = fit_range_ev
 
         #  Default fit range width is 100 eV for each line.

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -91,18 +91,22 @@ class EnergyCalibrationMaker:
              ):
         if ph is None:
             ph = np.array([], dtype=float)
+        else:
+            ph = np.asarray(ph)
         if energy is None:
             energy = np.array([], dtype=float)
+        else:
+            energy = np.asarray(energy)
         if dph is None:
             dph = 1e-3 * ph
+        else:
+            dph = np.asarray(dph)
         if de is None:
             de = 1e-3 * energy
+        else:
+            de = np.asarray(de)
         if names is None:
             names = ["dummy"] * len(dph)
-        ph = np.asarray(ph)
-        energy = np.asarray(energy)
-        dph = np.asarray(dph)
-        de = np.asarray(de)
         return cls(ph, energy, dph, de, names)
 
     def __post_init__(self):

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -7,13 +7,12 @@ Completely redesigned January 2025
 import numpy as np
 from scipy.optimize import brentq
 import pylab as plt
-# import numpy.typing as npt
+import numpy.typing as npt
 # from typing import Optional
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from mass.mathstat.interpolate import CubicSplineFunction, SmoothingSplineFunction, GPRSplineFunction
-from mass.mathstat.derivative import ExponentialFunction, Identity, LogFunction
+from mass.mathstat.interpolate import CubicSplineFunction, GPRSplineFunction
 from mass.calibration.nist_xray_database import NISTXrayDBFile
 
 
@@ -92,12 +91,12 @@ class EnergyCalibrationMaker:
 
         # First sort according to energy of the calibration point
         if not np.all(np.diff(self.energy) > 0):
-            idx = np.argsort(self.energy)
-            self.ph[:] = self.ph[idx]
-            self.energy[:] = self.energy[idx]
-            self.dph[:] = self.dph[idx]
-            self.de[:] = self.de[idx]
-            self.names[:] = [self.names[i] for i in idx]
+            sortkeys = np.argsort(self.energy)
+            self.ph[:] = self.ph[sortkeys]
+            self.energy[:] = self.energy[sortkeys]
+            self.dph[:] = self.dph[sortkeys]
+            self.de[:] = self.de[sortkeys]
+            self.names[:] = [self.names[i] for i in sortkeys]
 
         # Then confirm that the pulse heights are also in order
         order_ph = self.ph.argsort()
@@ -106,6 +105,10 @@ class EnergyCalibrationMaker:
             a = f"PH:     {self.ph[order_ph]}"
             b = f"Energy: {self.energy[order_ph]}"
             raise ValueError(f"Calibration points are not monotone:\n{a}\n{b}")
+
+    @property
+    def npts(self):
+        return len(self.ph)
 
     def _remove_cal_point_idx(self, idx):
         """Remove calibration point number `idx` from the calibration. Return a new maker."""
@@ -209,8 +212,483 @@ class EnergyCalibrationMaker:
             new_names[update_index] = name
         return EnergyCalibrationMaker(new_ph, new_energy, new_dph, new_de, new_names)
 
+    _ALLOWED_CURVNAMES = {
+        "linear", "linear+0", "loglog",
+        "gain", "invgain", "loggain",
+    }
 
-class EnergyCalibration:  # noqa: PLR0904
+    @staticmethod
+    def heuristic_samplepoints(anchors: npt.ArrayLike) -> np.ndarray:
+        """Given a set of calibration anchor points, return a few hundred
+        sample points, reasonably spaced below, between, and above the anchor points.
+
+        Parameters
+        ----------
+        anchors : ArrayLike
+            The anchor points (in pulse height space)
+
+        Returns
+        -------
+        np.ndarray
+            _description_
+        """
+        anchors = np.asarray(anchors)
+        # Prescription is 50 points up to lowest anchor (but exclude 0):
+        x = [np.linspace(0, anchors.min(), 51)[1:]]
+        # Then one points, plus one extra per 1% spacing between (and at) each anchor
+        for i in range(len(anchors) - 1):
+            low, high = anchors[i:i + 2]
+            n = 1 + int(100 * (high / low - 1) + 0.5)
+            x.append(np.linspace(low, high, n + 1)[1:])
+        # Finally, 100 more points between the highest anchor and 2x that.
+        x.append(anchors.max() * np.linspace(1, 2, 101)[1:])
+        return np.hstack(x)
+
+    def make_calibration(self, curvename="loglog", approximate=False, powerlaw=1.15):
+        if approximate and self.npts < 3:
+            raise ValueError(f"approximating curves require 3 or more cal anchor points, have {self.npts}")
+        if curvename not in self._ALLOWED_CURVNAMES:
+            raise ValueError(f"curvename='{curvename}', must be in {self._ALLOWED_CURVNAMES}")
+
+        # Use a heuristic to repair negative uncertainties.
+        def regularize_uncertainties(x):
+            if not np.any(x < 0):
+                return x
+            target = max(0.0, x.min())
+            x = x.copy()
+            x[x < 0] = target
+            return x
+        dph = regularize_uncertainties(self.dph)
+        de = regularize_uncertainties(self.de)
+
+        if curvename == "loglog":
+            input_transform = EnergyCalibration._ecal_input_log
+            output_transform = EnergyCalibration._ecal_output_log
+            x = np.log(self.ph)
+            y = np.log(self.energies)
+            # When there's only one point, enhance it by a fake point to enforce power-law behavior
+            if self.npts == 1:
+                arboffset = 1.0
+                x = np.hstack([x, x + arboffset])
+                y = np.hstack([y, y + arboffset / powerlaw])
+                dx = dph / self.ph
+                dy = de / self.energy
+
+        elif curvename == "gain":
+            input_transform = EnergyCalibration._ecal_input_identity
+            output_transform = EnergyCalibration._ecal_output_gain
+            x = self.ph
+            y = self.ph / self.energy
+            # Estimate spline uncertainties using slope of best-fit line
+            slope = np.polyfit(x, y, 1)[0]
+            dy = y * (((slope * self.energy - 1) * dph / x)**2 + (de / self.energy)**2)**0.5
+            dx = dph
+
+        elif curvename == "invgain":
+            input_transform = EnergyCalibration._ecal_input_identity
+            output_transform = EnergyCalibration._ecal_output_invgain
+            x = self.ph
+            y = self.energy / self.ph
+            # Estimate spline uncertainties using slope of best-fit line
+            slope = np.polyfit(x, y, 1)[0]
+            dy = y * (((slope * self.ph / y + 1) * dph / x)**2 + (de / self.energy)**2)**0.5
+            dx = dph
+
+        elif curvename in {"linear", "linear+0"}:
+            input_transform = EnergyCalibration._ecal_input_identity
+            output_transform = EnergyCalibration._ecal_output_identity
+            x = self.ph
+            y = self.energy
+            dx = dph
+            dy = de
+            if ("+0" in self.curvename()) and (0.0 not in x):
+                x = np.hstack(([0.0], x))
+                y = np.hstack(([0.0], y))
+                dx = np.hstack(([0.0], dx))
+                dy = np.hstack(([0.0], dy))
+
+        elif curvename == "loggain":
+            input_transform = EnergyCalibration._ecal_input_identity
+            output_transform = EnergyCalibration._ecal_output_loggain
+            x = self.ph
+            y = np.log(self.ph / self.energy)
+            # Estimate spline uncertainties using slope of best-fit line
+            slope = np.polyfit(x, y, 1)[0]
+            dy = y * (((slope * x - 1) * dph / x)**2 + (de / self.energy)**2)**0.5
+            dx = dph
+
+        else:
+            raise ValueError(f"curvename='{curvename}' not recognized")
+
+        if approximate:
+            internal_spline = GPRSplineFunction(x, y, dy, dx)
+        else:
+            internal_spline = CubicSplineFunction(x, y)
+
+        ph_samplepoints = EnergyCalibrationMaker.heuristic_samplepoints(self.ph)
+        E_samplepoints = output_transform(
+            ph_samplepoints,
+            internal_spline(input_transform(ph_samplepoints))
+        )
+        energy2ph = CubicSplineFunction(E_samplepoints, ph_samplepoints)
+
+        if approximate:
+            dspline = internal_spline.variance(ph_samplepoints)**0.5
+            if curvename == "loglog":
+                de_samplepoints = dspline * internal_spline(input_transform(ph_samplepoints))
+            elif curvename == "gain":
+                de_samplepoints = dspline * E_samplepoints**2 / ph_samplepoints
+            elif curvename == "invgain":
+                de_samplepoints = dspline * ph_samplepoints
+            elif curvename in {"linear", "linear+0"}:
+                de_samplepoints = dspline
+            elif curvename == "loggain":
+                abs_dfdp = np.abs(internal_spline(ph_samplepoints, der=1))
+                de_samplepoints = dspline * E_samplepoints * abs_dfdp
+            else:
+                raise ValueError(f"curvename='{curvename}' not recognized")
+
+            uncertainty_spline = CubicSplineFunction(ph_samplepoints, de_samplepoints)
+        else:
+            uncertainty_spline = np.zeros_like
+
+        return EnergyCalibration(
+            self.ph, self.energy, self.dph, self.de, self.names,
+            curvename=curvename,
+            approximating=approximate,
+            spline=internal_spline,
+            ph2uncertainty=uncertainty_spline,
+            input_transform=input_transform,
+            output_transform=output_transform,
+            energy2ph=energy2ph
+        )
+
+
+@dataclass(frozen=True)
+class EnergyCalibration:
+    """An energy calibration object that can convert pulse heights to (estimated) energies.
+
+    Subclasses implement the math of either exact or approximating calibration curves.
+    Methods allow you to convert between pulse heights and energies, estimate energy uncertainties,
+    and estimate pulse heights for lines whose names are know, or estimate the cal curve slope.
+    Methods allow you to plot the calibration curve with its anchor points.
+
+    Returns
+    -------
+    EnergyCalibration
+
+    Raises
+    ------
+    ValueError
+        _description_
+    """
+    ph: np.ndarray[np.float64]
+    energy: np.ndarray[np.float64]
+    dph: np.ndarray[np.float64]
+    de: np.ndarray[np.float64]
+    names: list[str]
+    curvename: str
+    approximating: bool
+    spline: Callable
+    ph2uncertainty: Callable
+    input_transform: Callable
+    output_transform: Callable | None = None
+    energy2ph: Callable | None = None
+
+    def __post_init__(self):
+        assert self.npts > 0
+
+    @property
+    def npts(self):
+        return len(self.ph)
+
+    @staticmethod
+    def _ecal_input_identity(ph, der=0):
+        "Use ph as the argument to the spline"
+        assert der >= 0
+        if der == 0:
+            return ph
+        elif der == 1:
+            return np.ones_like(ph)
+        return np.zeros_like(ph)
+
+    @staticmethod
+    def _ecal_input_log(ph, der=0):
+        "Use log(ph) as the argument to the spline"
+        assert der >= 0
+        if der == 0:
+            return np.log(ph)
+        elif der == 1:
+            return 1.0 / ph
+        raise ValueError(f"der={der}, should be one of (0,1)")
+
+    @staticmethod
+    def _ecal_output_identity(ph, yspline, der=0, dery=0):
+        "Use the spline result as E itself"
+        assert der >= 0 and dery >= 0
+        if der > 0:
+            return np.zeros_like(ph)
+        if dery == 0:
+            return yspline
+        elif dery == 1:
+            return np.ones_like(ph)
+        else:
+            return np.zeros_like(ph)
+
+    @staticmethod
+    def _ecal_output_log(ph, yspline, der=0, dery=0):
+        "Use the spline result as log(E)"
+        assert der >= 0 and dery >= 0
+        if der == 0:
+            # Any order of d/dy equals E(y) itself, or exp(y).
+            return np.exp(yspline)
+        else:
+            return np.zeros_like(ph)
+
+    @staticmethod
+    def _ecal_output_gain(ph, yspline, der=0, dery=0):
+        "Use the spline result as gain = ph/E"
+        assert der >= 0 and dery >= 0
+        if dery == 0:
+            if der == 0:
+                return ph / yspline
+            elif der == 1:
+                return 1.0 / yspline
+            else:
+                return np.zeros_like(ph)
+        assert dery == 1
+        return -ph / yspline**2
+
+    @staticmethod
+    def _ecal_output_invgain(ph, yspline, der=0, dery=0):
+        "Use the spline result as the inverse gain = E/ph"
+        assert der >= 0 and dery >= 0
+        if dery == 0:
+            if der == 0:
+                return ph * yspline
+            elif der == 1:
+                return yspline
+            else:
+                return np.zeros_like(ph)
+        assert dery == 1
+        return ph
+
+    @staticmethod
+    def _ecal_output_loggain(ph, yspline, der=0, dery=0):
+        "Use the spline result as the log of the gain, or log(ph/E)"
+        assert der >= 0 and dery >= 0
+        if dery == 0:
+            if der == 0:
+                return ph * np.exp(-yspline)
+            elif der == 1:
+                return np.exp(-yspline)
+            else:
+                return np.zeros_like(ph)
+        assert dery == 1
+        return -ph * np.exp(-yspline)
+
+    @property
+    def ismonotonic(self):
+        """Is the curve monotonic from 0 to 1.05 times the max anchor point's pulse height?
+        Test at 1001 points, equally spaced in pulse height."""
+        nsamples = 1001
+        ph = np.linspace(0, 1.05 * self.ph.max(), nsamples)
+        e = self(ph)
+        return np.all(np.diff(e) > 0)
+
+    def name2ph(self, name):
+        """Convert a named energy feature to pulse height. `name` need not be a calibration point."""
+        energy = STANDARD_FEATURES[name]
+        return self.energy2ph(energy)
+
+    def energy2dedph(self, energy):
+        """Calculate the slope at energy."""
+        return self.ph2dedph(self.energy2ph(energy))
+
+    def energy2uncertainty(self, energies):
+        """Cal uncertainty in eV at the given pulse heights."""
+        ph = self.energy2ph(energies)
+        return self.ph2uncertainty(ph)
+
+    def __str__(self):
+        seq = [f"EnergyCalibration({self.curvename})"]
+        for name, pulse_ht, energy in zip(self.names, self.ph, self.energy):
+            seq.append(f"  energy(ph={pulse_ht:7.2f}) --> {energy:9.2f} eV ({name})")
+        return "\n".join(seq)
+
+    def ph2energy(self, ph, exact=False):
+        x = self.input_transform(ph)
+        y = self.spline(x)
+        E = self.output_transform(ph, y)
+        return E
+
+    __call__ = ph2energy
+
+    def ph2dedph(self, ph):
+        """Calculate the slope at pulse heights `ph`."""
+        x = self.input_transform(ph)
+        dgdP = self.input_transform(ph, der=1)
+        dydx = self.spline(x, der=1)
+        dEdP = dydx * dgdP
+        if self.output_transform is not None:
+            y = self.spline(x)
+            dfdP = self.output_transform(ph, y, der=1)
+            dfdy = self.output_transform(ph, y, dery=1)
+            dEdP = dfdP + dfdy * dydx * dgdP
+        return dEdP
+
+    def energy2ph_exact(self, E):
+        # TODO use the spline as a starting point for Brent's method
+        return self.energy2ph(E)
+
+    def save_to_hdf5(self, hdf5_group, name):
+        if name in hdf5_group:
+            del hdf5_group[name]
+
+        cal_group = hdf5_group.create_group(name)
+        cal_group["name"] = [_name.encode() for _name in self.names]
+        cal_group["ph"] = self.ph
+        cal_group["energy"] = self.energy
+        cal_group["dph"] = self.dph
+        cal_group["de"] = self.de
+        cal_group.attrs['nonlinearity'] = self.nonlinearity
+        cal_group.attrs['curvetype'] = self.curvename
+        cal_group.attrs['approximate'] = self.approximating
+
+    @staticmethod
+    def load_from_hdf5(hdf5_group, name):
+        cal_group = hdf5_group[name]
+
+        # Fix a behavior of h5py for writing in py2, reading in py3.
+        curvetype = cal_group.attrs['curvetype']
+        if isinstance(curvetype, bytes):
+            curvetype = curvetype.decode("utf-8")
+
+        maker = EnergyCalibrationMaker(
+            cal_group["ph"][:],
+            cal_group["energy"][:],
+            cal_group["dph"][:],
+            cal_group["de"][:],
+            cal_group["name"][:]
+        )
+        # powerlaw = cal_group.attrs['nonlinearity']
+        approximate = cal_group.attrs['approximate']
+        return maker.make_calibration(curvetype, approximate=approximate)
+
+    def plotgain(self, **kwargs):
+        kwargs["plottype"] = "gain"
+        self.plot(**kwargs)
+
+    def plotinvgain(self, **kwargs):
+        kwargs["plottype"] = "invgain"
+        self.plot(**kwargs)
+
+    def plotloggain(self, **kwargs):
+        kwargs["plottype"] = "loggain"
+        self.plot(**kwargs)
+
+    def plot(self, axis=None, color="blue", markercolor="red", plottype="linear", ph_rescale_power=0.0,  # noqa: PLR0917
+             removeslope=False, energy_x=False, showtext=True, showerrors=True, min_energy=None, max_energy=None):
+        # Plot smooth curve
+        minph, maxph = self.ph.min() * .9, self.ph.max() * 1.1
+        if min_energy is not None:
+            minph = self.e2ph(min_energy)
+        if max_energy is not None:
+            maxph = self.e2ph(max_energy)
+        phplot = np.linspace(minph, maxph, 1000)
+        eplot = self(phplot)
+        gplot = phplot / eplot
+        dyplot = None
+        gains = self.ph / self.energy
+        slope = 0.0
+        xplot = phplot
+        x = self.ph
+        xerr = self.dph
+        if energy_x:
+            xplot = eplot
+            x = self.energy
+            xerr = self.de
+
+        if axis is None:
+            plt.clf()
+            axis = plt.subplot(111)
+            # axis.set_xlim([x[0], x[-1]*1.1])
+        if energy_x:
+            axis.set_xlabel("Energy (eV)")
+        else:
+            axis.set_xlabel("Pulse height")
+
+        if plottype == "linear":
+            yplot = self(phplot) / (phplot**ph_rescale_power)
+            if self.approximating:
+                dyplot = self.ph2uncertainty(phplot) / (phplot**ph_rescale_power)
+            y = self.energy / (self.ph**ph_rescale_power)
+            if ph_rescale_power == 0.0:
+                ylabel = "Energy (eV)"
+                axis.set_title("Energy calibration curve")
+            else:
+                ylabel = f"Energy (eV) / PH^{ph_rescale_power:.4f}"
+                axis.set_title(f"Energy calibration curve, scaled by {ph_rescale_power:.4f} power of PH")
+        elif plottype == "gain":
+            yplot = gplot
+            if self.approximating:
+                dyplot = self.ph2uncertainty(phplot) / eplot * gplot
+            y = gains
+            ylabel = "Gain (PH/eV)"
+            axis.set_title("Energy calibration curve, gain")
+        elif plottype == "invgain":
+            yplot = 1.0 / gplot
+            if self.approximating:
+                dyplot = self.ph2uncertainty(phplot) / phplot
+            y = 1.0 / gains
+            ylabel = "Inverse Gain (eV/PH)"
+            axis.set_title("Energy calibration curve, inverse gain")
+        elif plottype == "loggain":
+            yplot = np.log(gplot)
+            if self.approximating:
+                dyplot = self.ph2uncertainty(phplot) / eplot
+            y = np.log(gains)
+            ylabel = "Log Gain: log(eV/PH)"
+            axis.set_title("Energy calibration curve, log gain")
+        elif plottype == "loglog":
+            yplot = np.log(eplot)
+            xplot = np.log(phplot)
+            if self.approximating:
+                dyplot = self.ph2uncertainty(phplot) / eplot
+            y = np.log(self.energy)
+            x = np.log(self.ph)
+            xerr = (self.dph / self.ph)
+            ylabel = "Log energy/1 eV"
+            axis.set_xlabel("log(Pulse height/arbs)")
+            axis.set_title("Energy calibration curve, log gain")
+        else:
+            raise ValueError("plottype must be one of ('linear', 'gain','loggain','invgain').")
+
+        if removeslope:
+            slope = (y[-1] - y[0]) / (x[-1] - x[0])
+            yplot -= slope * xplot
+
+        axis.plot(xplot, yplot, color=color)
+        if dyplot is not None and showerrors:
+            axis.plot(xplot, yplot + dyplot, color=color, alpha=0.35)
+            axis.plot(xplot, yplot - dyplot, color=color, alpha=0.35)
+
+        # Plot and label cal points
+        dy = ((self.de / self.energy)**2 + (self.dph / self.ph)**2)**0.5 * y
+        axis.errorbar(x, y - slope * x, yerr=dy, xerr=xerr, fmt='o',
+                      mec='black', mfc=markercolor, capsize=0)
+        axis.grid(True)
+        if removeslope:
+            ylabel = f"{ylabel} slope removed"
+        axis.set_ylabel(ylabel)
+        if showtext:
+            for xval, name, yval in zip(x, self.names, y):
+                axis.text(xval, yval - slope * xval, name + '  ', ha='right')
+
+
+################################################################################################
+
+class OldEnergyCalibration:  # noqa: PLR0904
     """Object to store information relevant to one detector's absolute energy
     calibration and to offer conversions between pulse height and energy.
 
@@ -232,101 +710,7 @@ class EnergyCalibration:  # noqa: PLR0904
 
     The inverse conversion method energy2ph calls Brent's method of root-finding.
     It's probably quite slow compared to a self.ph2energy for an array of equal length.
-
-    All of __call__, ph2energy, and energy2ph should return a scalar when given a
-    scalar input, or a matching numpy array when given any sequence as an input.
     """
-
-    CURVETYPE = (
-        "loglog",
-        "linear",
-        "linear+0",
-        "gain",
-        "invgain",
-        "loggain",
-    )
-
-    def __init__(self, nonlinearity=1.1, curvetype="loglog", approximate=False,
-                 useGPR=True):
-        """Create an EnergyCalibration object for pulse-height-related field.
-
-        Args:
-            nonlinearity (float): the exponent N in the default, low-energy limit of
-                E propto (PH)^N.  Typically 1.0 to 1.3 are reasonable.
-            curvetype (str or int): one of EnergyCalibration.CURVETYPE.
-            approximate (boolean):  Whether to use approximate "smoothing splines". (If not, use splines
-                that go exactly through the data.) Default = False, because this works
-                poorly unless the user calls with sensible PH and Energy uncertainties.
-            useGPR (boolean): whether to use the new GPR-style choice for smoothing splines.
-                Default True, but set False to use the pre-2021 approximation method.
-        """
-        self._curvetype = 0
-        self.set_curvetype(curvetype)
-        self._ph2e = self.__default_ph2e
-        self._e2ph = self.__default_ph2e
-        self._ph = np.zeros(0, dtype=float)
-        self._energies = np.zeros(0, dtype=float)
-        self._dph = np.zeros(0, dtype=float)
-        self._de = np.zeros(0, dtype=float)
-        self._names = []
-        self.npts = 0
-        self._use_approximation = approximate
-        self._use_GPR = useGPR
-        self._model_is_stale = False
-        self._e2phwarned = False
-        self.nonlinearity = nonlinearity
-        self.set_nonlinearity()
-
-    @staticmethod
-    def __default_ph2e(x, der=0):
-        if der > 0:
-            return np.zeros_like(x)
-        return x
-
-    def __call__(self, pulse_ht, der=0):
-        return self.ph2energy(pulse_ht, der=der)
-
-    def ph2energy(self, pulse_ht, der=0):
-        """Convert pulse height (or array of pulse heights) <pulse_ht> to energy (in eV).
-        Should return a scalar if passed a scalar, and a numpy array if passed a list or array
-
-        Args:
-            pulse_ht (float or np.array(dtype=float)): pulse heights in an arbitrary unit.
-            der (int): the order of derivative. `der` should be >= 0.
-        """
-        if self._model_is_stale:
-            self._update_converters()
-        result = self._ph2e(pulse_ht, der=der)
-
-        if np.isscalar(pulse_ht):
-            if np.isscalar(result):
-                return result
-            return result.item()
-
-        # Change any inf or NaN results to 0.0 energy.
-        if any(np.isnan(result)):
-            result[np.isnan(result)] = 0.0
-        if any(np.isinf(result)):
-            result[np.isinf(result)] = 0.0
-        return np.array(result)
-
-    def energy2ph(self, energy):
-        """Convert energy (or array of energies) `energy` to pulse height in arbs.
-
-        Should return a scalar if passed a scalar, and a numpy array if passed a list or array
-        Uses a spline with steps no greater than ~1% in pulse height space. For a Brent's
-        method root finding (i.e., an actual inversion of the ph->energy function), use
-        method `energy2ph_exact`.
-        """
-        if self._model_is_stale:
-            self._update_converters()
-        result = self._e2ph(energy)
-
-        if np.isscalar(energy):
-            if np.isscalar(result):
-                return result
-            return result.item()
-        return np.array(result)
 
     def energy2ph_exact(self, energy):
         """Convert energy (or array of energies) `energy` to pulse height in arbs.
@@ -358,526 +742,6 @@ class EnergyCalibration:  # noqa: PLR0904
         result = [brentq(energy_residual, 1e-6, self._max_ph, args=(e,)) for e in energy]
         return np.array(result)
 
-    def ph2dedph(self, ph):
-        """Calculate the slope at pulse heights `ph`."""
-        if self._model_is_stale:
-            self._update_converters()
-        return self(ph, der=1)
-
-    def energy2dedph(self, energy):
-        """Calculate the slope at energy."""
-        return self.ph2dedph(self.energy2ph(energy))
-
-    def ph2uncertainty(self, ph):
-        """Cal uncertainty in eV at the given pulse heights."""
-        if not self._use_approximation:
-            raise ValueError(
-                "Cannot estimate uncertainty. First use cal.set_use_approximation(True)")
-        if self._model_is_stale:
-            self._update_converters()
-        return self._uncertainty(ph)
-
-    def energy2uncertainty(self, energies):
-        """Cal uncertainty in eV at the given pulse heights."""
-        ph = self.energy2ph(energies)
-        return self.ph2uncertainty(ph)
-
-    def e2ph(self, energy): return self.energy2ph(energy)
-
-    def e2dedph(self, energy): return self.energy2dedph(energy)
-
-    def e2uncertainty(self, energy): return self.energy2uncertainty(energy)
-
-    def __str__(self):
-        self._update_converters()  # To sort the points
-        seq = ["EnergyCalibration()"]
-        for name, pulse_ht, energy in zip(self._names, self._ph, self._energies):
-            seq.append(f"  energy(ph={pulse_ht:7.2f}) --> {energy:9.2f} eV ({name})")
-        return "\n".join(seq)
-
-    def set_nonlinearity(self, powerlaw=1.15):
-        """Update the power law index assumed when there's 1 data point and a loglog curve type."""
-        if self.curvename() == "loglog" and powerlaw != self.nonlinearity:
-            self._model_is_stale = True
-        self.nonlinearity = powerlaw
-
-    def set_use_approximation(self, useit):
-        """Switch to using (or to NOT using) approximating splines with
-        reduced knot count. You can interchange this with adding points, because
-        the actual model computation isn't done until the cal curve is called."""
-        if useit != self._use_approximation:
-            self._use_approximation = useit
-            self._model_is_stale = True
-
-    def set_GPR(self, useit):
-        if useit != self._use_GPR:
-            self._use_GPR = useit
-            self._model_is_stale = True
-
-    def set_curvetype(self, curvetype):
-        if isstr(curvetype):
-            # Fix a behavior of h5py for writing in py2, reading in py3.
-            if isinstance(curvetype, bytes):
-                curvetype = curvetype.decode("utf-8")
-            try:
-                curvetype = self.CURVETYPE.index(curvetype.lower())
-            except ValueError:
-                raise ValueError(f"EnergyCalibration.CURVETYPE does not contain '{curvetype}'")
-        assert 0 <= curvetype < len(self.CURVETYPE)
-
-        if curvetype != self._curvetype:
-            self._curvetype = curvetype
-            self._model_is_stale = True
-
-    def curvename(self):
-        return self.CURVETYPE[self._curvetype]
-
-    def copy(self):
-        """Return a deep copy."""
-        ecal = EnergyCalibration()
-        ecal.__dict__.update(self.__dict__)
-        ecal._names = list(self._names)
-        ecal._ph = self._ph.copy()
-        ecal._energies = self._energies.copy()
-        ecal._dph = self._dph.copy()
-        ecal._de = self._de.copy()
-        ecal._use_approximation = self._use_approximation
-        ecal._use_GPR = self._use_GPR
-        ecal._model_is_stale = True
-        ecal._curvetype = self._curvetype
-        return ecal
-
-    def _remove_cal_point_idx(self, idx):
-        """Remove calibration point number `idx` from the calibration."""
-        self._names.pop(idx)
-        self._ph = np.hstack((self._ph[:idx], self._ph[idx + 1:]))
-        self._energies = np.hstack((self._energies[:idx], self._energies[idx + 1:]))
-        self._dph = np.hstack((self._dph[:idx], self._dph[idx + 1:]))
-        self._de = np.hstack((self._de[:idx], self._de[idx + 1:]))
-        self.npts -= 1
-        self._model_is_stale = True
-
-    def remove_cal_point_name(self, name):
-        """If you don't like calibration point named <name>, this removes it."""
-        idx = self._names.index(name)
-        self._remove_cal_point_idx(idx)
-
-    def remove_cal_point_prefix(self, prefix):
-        """This removes all cal points whose name starts with <prefix>.  Return number removed."""
-        for name in tuple(self._names):
-            if name.startswith(prefix):
-                self.remove_cal_point_name(name)
-
-    def remove_cal_point_energy(self, energy, de):
-        """Remove cal points at energies with <de> of <energy>"""
-        idxs = np.nonzero(np.abs(self._energies - energy) < de)[0]
-
-        for idx in idxs:
-            self._remove_cal_point_idx(idx)
-
-    def add_cal_point(self, pht, energy, name="", pht_error=None, e_error=None, overwrite=True):
-        """Add a single energy calibration point <pht>, <energy>,
-
-        <pht> must be in units of the self.ph_field and <energy> is in eV.
-        <pht_error> is the 1-sigma uncertainty on the pulse height.  If None
-        (the default), then assign pht_error = <pht>/1000. <e_error> is the
-        1-sigma uncertainty on the energy itself. If None (the default), then
-        assign e_error=<energy>/10^5 (typically 0.05 eV).
-
-        Also, you can call it with <energy> as a string, provided it's the name
-        of a known feature appearing in the dictionary
-        mass.energy_calibration.STANDARD_FEATURES.  Thus the following are
-        equivalent:
-
-        cal.add_cal_point(12345.6, 5898.801, "Mn Ka1")
-        cal.add_cal_point(12456.6, "Mn Ka1")
-
-        Careful!  If you give a name that's already in the list, then this value
-        replaces the previous one.  If you do NOT give a name, though, then this
-        will NOT replace but will add to any existing points at the same energy.
-        You can prevent overwriting by setting <overwrite>=False.
-        """
-        self._model_is_stale = True
-
-        # If <energy> is a string and a known spectral feature's name, use it as the name instead
-        # Otherwise, it needs to be a numeric type convertible to float.
-        # if energy in STANDARD_FEATURES:
-        #     name = energy
-        #     energy = STANDARD_FEATURES[name]
-        # else:
-        try:
-            energy = float(energy)
-        except ValueError:
-            try:
-                name = energy
-                energy = STANDARD_FEATURES[name]
-            except Exception:
-                raise ValueError("2nd argument must be an energy or a known name"
-                                 + " from mass.energy_calibration.STANDARD_FEATURES")
-
-        if pht_error is None:
-            pht_error = pht * 0.001
-        if e_error is None:
-            e_error = 0.01  # Assume 0.01 eV error if none given
-
-        update_index = None
-        if name and name in self._names:  # Update an existing point by name
-            if not overwrite:
-                raise ValueError(
-                    f"Calibration point '{name}' is already known and overwrite is False")
-            update_index = self._names.index(name)
-
-        elif self.npts > 0 and np.abs(energy - self._energies).min() <= e_error:  # Update existing point
-            if not overwrite:
-                raise ValueError(
-                    f"Calibration point at energy {energy:.2f} eV is already known and overwrite is False")
-            update_index = np.abs(energy - self._energies).argmin()
-
-        if update_index is None:   # Add a new point
-            self._ph = np.hstack((self._ph, pht))
-            self._energies = np.hstack((self._energies, energy))
-            self._dph = np.hstack((self._dph, pht_error))
-            self._de = np.hstack((self._de, e_error))
-            self._names.append(name)
-        else:
-            self._ph[update_index] = pht
-            self._energies[update_index] = energy
-            self._dph[update_index] = pht_error
-            self._de[update_index] = e_error
-        self.npts = len(self._ph)
-
-        # Validate: ph and energies must be monotone increasing
-        order_ph = self._ph.argsort()
-        order_en = self._energies.argsort()
-        if not np.all(order_ph == order_en):
-            a = f"PH:     {self._ph[order_ph]}"
-            b = f"Energy: {self._energies[order_ph]}"
-            raise Exception(f"Calibration points are not monotone:\n{a}\n{b}")
-
-    @property
-    def cal_point_phs(self):
-        return self._ph
-
-    @property
-    def cal_point_energies(self):
-        return self._energies
-
-    @property
-    def cal_point_names(self):
-        return self._names
-
-    @property
-    def ismonotonic(self):
-        "Is the curve monotonic from 0 to 1.05 times the max anchor point's pulse height?"
-        npoints = 1001
-        ph = np.linspace(0, 1.05 * self._ph.max(), npoints)
-        e = self(ph)
-        return np.all(np.diff(e) > 0)
-
-    def _update_converters(self):
-        """There is now one (or more) new data points. All the math goes on in this method."""
-        # Sort in ascending energy order
-        sortkeys = np.argsort(self._ph)
-        self._ph = self._ph[sortkeys]
-        self._energies = self._energies[sortkeys]
-        self._dph = self._dph[sortkeys]
-        self._de = self._de[sortkeys]
-        self._names = [self._names[s] for s in sortkeys]
-
-        assert self.npts == len(self._ph)
-        assert self.npts == len(self._dph)
-        assert self.npts == len(self._energies)
-        assert self.npts == len(self._de)
-
-        self._max_ph = 2 * np.max(self._ph)
-        # Compute cal curve inverse and (if GPRSplined, the variance) at these points
-        ph = self._ph
-        ph_pts = [np.linspace(0, ph[0], 51)[1:]]
-        for i in range(len(ph) - 1):
-            npts = 2 + int(0.5 + (ph[i + 1] / ph[i] - 1) * 100)
-            ph_pts.append(np.linspace(ph[i], ph[i + 1], npts)[1:])
-        ph_pts.append(np.linspace(ph[-1], 2 * ph[-1], 101)[1:])
-        ph_pts = np.hstack(ph_pts)
-
-        if self._use_approximation and self.npts >= 3:
-            self._update_approximators(ph_pts)
-        else:
-            self._update_exactcurves()
-        self._e2ph = CubicSplineFunction(self._ph2e(ph_pts), ph_pts)
-        self._model_is_stale = False
-
-    def _update_approximators(self, ph_pts):
-        "Update approximating spline. Find and spline variance at points `ph_pts`"
-        PreferredSpline = GPRSplineFunction
-        if not self._use_GPR:
-            PreferredSpline = SmoothingSplineFunction
-
-        # Make sure the errors in both dimensions are reasonable (positive)
-        if (self._dph <= 0.0).any():
-            if (self._dph > 0).any():
-                self._dph[self._dph <= 0.0] = self._dph[self._dph > 0].min()
-            else:
-                self._dph = np.zeros_like(self._dph)
-        if (self._de <= 0.0).any():
-            if (self._de > 0).any():
-                self._de[self._de <= 0.0] = self._de[self._de > 0].min()
-            else:
-                self._de = np.zeros_like(self._de)
-
-        # Find transformed data. For dy, assume that E and PH errors are uncorrelated.
-        ph, dph, e, de = self._ph, self._dph, self._energies, self._de
-
-        if self.curvename() == "loglog":
-            underlying_spline = PreferredSpline(np.log(ph), np.log(e), de / e, dph / ph)
-            self._ph2e = ExponentialFunction() << underlying_spline << LogFunction()
-            cal_uncert = underlying_spline(ph_pts) * underlying_spline.variance(np.log(ph_pts))**0.5
-
-        elif self.curvename().startswith("linear"):
-            if ("+0" in self.curvename()) and (0.0 not in ph):
-                ph = np.hstack([[0], ph])
-                e = np.hstack([[0], e])
-                de = np.hstack([[de.min() * 0.1], de])
-                dph = np.hstack([[dph.min() * 0.1], dph])
-            underlying_spline = PreferredSpline(ph, e, de, dph)
-            self._ph2e = underlying_spline
-            cal_uncert = underlying_spline.variance(ph_pts)**0.5
-
-        elif self.curvename() == "gain":
-            g = ph / e
-            m = np.polyfit(ph, g, 1)[0]
-            dg = g * (((m * ph / g - 1) * dph / ph)**2 + (de / e)**2)**0.5
-            underlying_spline = PreferredSpline(ph, g, dg)
-            p = Identity()
-            self._ph2e = p / (underlying_spline << p)
-            est_g = underlying_spline(ph_pts)
-            est_e = ph_pts / est_g
-            cal_uncert = underlying_spline.variance(ph_pts)**0.5 * est_e / est_g
-
-            # Gain curves have a problem: gain<0 screws it all up. Avoid that region.
-            trial_phmax = 10 * self._ph.max()
-            if underlying_spline(trial_phmax) > 0:
-                self._max_ph = trial_phmax
-
-        elif self.curvename() == "invgain":
-            ig = e / ph
-            m = np.polyfit(ph, ig, 1)[0]
-            d_ig = ig * (((1 + m * ph / ig) * dph / ph)**2 + (de / e)**2)**0.5
-            p = Identity()
-            underlying_spline = PreferredSpline(ph, ig, d_ig)
-            self._ph2e = p * (underlying_spline << p)
-            cal_uncert = underlying_spline.variance(ph_pts)**0.5 * ph_pts
-
-        elif self.curvename() == "loggain":
-            lg = np.log(ph / e)
-            m = np.polyfit(ph, lg, 1)[0]
-            d_lg = (((m * ph - 1) * dph / ph)**2 + (de / e)**2)**0.5
-            p = Identity()
-            underlying_spline = PreferredSpline(ph, lg, d_lg)
-            self._ph2e = p * (ExponentialFunction() << (-underlying_spline << p))
-            e_pts = self._ph2e(ph_pts)
-            dfdp = underlying_spline(ph_pts, der=1)
-            cal_uncert = underlying_spline.variance(ph_pts)**0.5 * e_pts * np.abs(dfdp)
-
-        self._underlying_spline = underlying_spline
-        if self._use_GPR:
-            self._uncertainty = CubicSplineFunction(ph_pts, cal_uncert)
-        else:
-            self._uncertainty = np.zeros_like
-
-    def _update_exactcurves(self):
-        """Update the E(P) curve; assume exact interpolation of calibration data."""
-        # Choose proper curve/interpolating function object
-        # For N=0 points, in the absence of any information at all, we just let E = PH.
-        # For N=1 points, use E proportional to PH (or if loglog curve, then a power law of
-        #    the assumed nonlinearity).
-        # For N>1 points, use the chosen curve type (but for N=2, recall that the spline will be a line).
-        if self.npts <= 0:
-            # self._ph2e = lambda p: p
-            self._ph2e = Identity()
-
-        elif self.npts == 1:
-            p1 = self._ph[0]
-            e1 = self._energies[0]
-            if self.curvename() == "loglog":
-                self._ph2e = e1 * (Identity() / p1)**self.nonlinearity
-            elif self.curvename() in {"gain", "invgain"}:
-                self._ph2e = (e1 / p1) * Identity()
-            else:
-                raise Exception(f"curvename={self.curvename()} not implemented for npts=1")
-
-        elif self.curvename() == "loglog":
-            x = np.log(self._ph)
-            y = np.log(self._energies)
-            # self._x2yfun = CubicSpline(x, y)
-            # self._ph2e = lambda p: np.exp(self._x2yfun(np.log(p)))
-            underlying_spline = CubicSplineFunction(x, y)
-            self._ph2e = ExponentialFunction() << underlying_spline << LogFunction()
-
-        elif self.curvename().startswith("linear"):
-            x = self._ph
-            y = self._energies
-            if ("+0" in self.curvename()) and (0.0 not in x):
-                x = np.hstack(([0], x))
-                y = np.hstack(([0], y))
-            # self._ph2e = CubicSpline(x, y)
-            self._ph2e = CubicSplineFunction(x, y)
-
-        elif self.curvename() == "gain":
-            x = self._ph
-            y = x / self._energies
-            # self._underlying_spline = CubicSpline(x, y)
-            # self._ph2e = lambda p: p/self._underlying_spline(p)
-            underlying_spline = CubicSplineFunction(x, y)
-            self._ph2e = Identity() / underlying_spline
-
-            # Gain curves have a problem: gain<0 screws it all up. Avoid that region.
-            trial_phmax = 10 * self._ph.max()
-            if underlying_spline(trial_phmax) > 0:
-                self._max_ph = trial_phmax
-            else:
-                self._max_ph = 0.99 * brentq(underlying_spline, 0, trial_phmax)
-
-        elif self.curvename() == "invgain":
-            x = self._ph
-            y = self._energies / x
-            # self._underlying_spline = CubicSpline(x, y)
-            # self._ph2e = lambda p: p*self._underlying_spline(p)
-            underlying_spline = CubicSplineFunction(x, y)
-            self._ph2e = Identity() * underlying_spline
-
-        elif self.curvename() == "loggain":
-            x = self._ph
-            y = np.log(x / self._energies)
-            # self._underlying_spline = CubicSpline(x, y)
-            # self._ph2e = lambda p: p*np.exp(-self._underlying_spline(p))
-            underlying_spline = CubicSplineFunction(x, y)
-            self._ph2e = Identity() * (ExponentialFunction() << -underlying_spline)
-
-        ph = self._ph
-        ph_pts = [np.linspace(0, ph[0], 51)[1:]]
-        for i in range(len(ph) - 1):
-            npts = 2 + int(0.5 + (ph[i + 1] / ph[i] - 1) * 100)
-            ph_pts.append(np.linspace(ph[i], ph[i + 1], npts)[1:])
-        ph_pts.append(np.linspace(ph[-1], 2 * ph[-1], 101)[1:])
-        ph_pts = np.hstack(ph_pts)
-        self._e2ph = CubicSplineFunction(self._ph2e(ph_pts), ph_pts)
-
-    def name2ph(self, name):
-        """Convert a named energy feature to pulse height. `name` need not be a calibration point."""
-        energy = STANDARD_FEATURES[name]
-        return self.energy2ph(energy)
-
-    def plotgain(self, **kwargs):
-        kwargs["plottype"] = "gain"
-        self.plot(**kwargs)
-
-    def plotinvgain(self, **kwargs):
-        kwargs["plottype"] = "invgain"
-        self.plot(**kwargs)
-
-    def plotloggain(self, **kwargs):
-        kwargs["plottype"] = "loggain"
-        self.plot(**kwargs)
-
-    def plot(self, axis=None, color="blue", markercolor="red", plottype="linear", ph_rescale_power=0.0,  # noqa: PLR0917
-             removeslope=False, energy_x=False, showtext=True, showerrors=True, min_energy=None, max_energy=None):
-        # Plot smooth curve
-        minph, maxph = self._ph.max() * .001, self._ph.max() * 1.1
-        if min_energy is not None:
-            minph = self.e2ph(min_energy)
-        if max_energy is not None:
-            maxph = self.e2ph(max_energy)
-        phplot = np.linspace(minph, maxph, 1000)
-        eplot = self(phplot)
-        gplot = phplot / eplot
-        dyplot = None
-        gains = self._ph / self._energies
-        slope = 0.0
-        xplot = phplot
-        x = self._ph
-        xerr = self._dph
-        if energy_x:
-            xplot = eplot
-            x = self._energies
-            xerr = self._de
-
-        import pylab as plt  # noqa: PLC0415
-        if axis is None:
-            plt.clf()
-            axis = plt.subplot(111)
-            # axis.set_xlim([x[0], x[-1]*1.1])
-        if energy_x:
-            axis.set_xlabel("Energy (eV)")
-        else:
-            axis.set_xlabel("Pulse height")
-
-        if plottype == "linear":
-            yplot = self(phplot) / (phplot**ph_rescale_power)
-            if self._use_approximation:
-                dyplot = self.ph2uncertainty(phplot) / (phplot**ph_rescale_power)
-            y = self._energies / (self._ph**ph_rescale_power)
-            if ph_rescale_power == 0.0:
-                ylabel = "Energy (eV)"
-                axis.set_title("Energy calibration curve")
-            else:
-                ylabel = f"Energy (eV) / PH^{ph_rescale_power:.4f}"
-                axis.set_title(f"Energy calibration curve, scaled by {ph_rescale_power:.4f} power of PH")
-        elif plottype == "gain":
-            yplot = gplot
-            if self._use_approximation:
-                dyplot = self.ph2uncertainty(phplot) / eplot * gplot
-            y = gains
-            ylabel = "Gain (PH/eV)"
-            axis.set_title("Energy calibration curve, gain")
-        elif plottype == "invgain":
-            yplot = 1.0 / gplot
-            if self._use_approximation:
-                dyplot = self.ph2uncertainty(phplot) / phplot
-            y = 1.0 / gains
-            ylabel = "Inverse Gain (eV/PH)"
-            axis.set_title("Energy calibration curve, inverse gain")
-        elif plottype == "loggain":
-            yplot = np.log(gplot)
-            if self._use_approximation:
-                dyplot = self.ph2uncertainty(phplot) / eplot
-            y = np.log(gains)
-            ylabel = "Log Gain: log(eV/PH)"
-            axis.set_title("Energy calibration curve, log gain")
-        elif plottype == "loglog":
-            yplot = np.log(eplot)
-            xplot = np.log(phplot)
-            if self._use_approximation:
-                dyplot = self.ph2uncertainty(phplot) / eplot
-            y = np.log(self._energies)
-            x = np.log(self._ph)
-            xerr = (self._dph / self._ph)
-            ylabel = "Log energy/1 eV"
-            axis.set_xlabel("log(Pulse height/arbs)")
-            axis.set_title("Energy calibration curve, log gain")
-        else:
-            raise ValueError("plottype must be one of ('linear', 'gain','loggain','invgain').")
-
-        if removeslope:
-            slope = (y[-1] - y[0]) / (x[-1] - x[0])
-            yplot -= slope * xplot
-
-        axis.plot(xplot, yplot, color=color)
-        if dyplot is not None and showerrors:
-            axis.plot(xplot, yplot + dyplot, color=color, alpha=0.35)
-            axis.plot(xplot, yplot - dyplot, color=color, alpha=0.35)
-
-        # Plot and label cal points
-        dy = ((self._de / self._energies)**2 + (self._dph / self._ph)**2)**0.5 * y
-        axis.errorbar(x, y - slope * x, yerr=dy, xerr=xerr, fmt='o',
-                      mec='black', mfc=markercolor, capsize=0)
-        axis.grid(True)
-        if removeslope:
-            ylabel = f"{ylabel} slope removed"
-        axis.set_ylabel(ylabel)
-        if showtext:
-            for xval, name, yval in zip(x, self._names, y):
-                axis.text(xval, yval - slope * xval, name + '  ', ha='right')
-
     def drop_one_errors(self):
         """For each calibration point, calculate the difference between the 'correct' energy
         and the energy predicted by creating a calibration without that point and using
@@ -891,44 +755,3 @@ class EnergyCalibration:  # noqa: PLR0904
             drop_one_energy_diff[i] = predicted_energy - drop_one_energy
         perm = np.argsort(self._energies)
         return self._energies[perm], drop_one_energy_diff[perm]
-
-    def save_to_hdf5(self, hdf5_group, name):
-        if name in hdf5_group:
-            del hdf5_group[name]
-
-        cal_group = hdf5_group.create_group(name)
-        cal_group["name"] = [_name.encode() for _name in self._names]
-        cal_group["ph"] = self._ph
-        cal_group["energy"] = self._energies
-        cal_group["dph"] = self._dph
-        cal_group["de"] = self._de
-        cal_group.attrs['nonlinearity'] = self.nonlinearity
-        cal_group.attrs['curvetype'] = self.CURVETYPE[self._curvetype]
-        cal_group.attrs['approximate'] = self._use_approximation
-
-    @classmethod
-    def load_from_hdf5(cls, hdf5_group, name):
-        cal_group = hdf5_group[name]
-        cal = cls(cal_group.attrs['nonlinearity'],
-                  cal_group.attrs['curvetype'],
-                  cal_group.attrs['approximate'])
-
-        _names = cal_group["name"][:]
-        _ph = cal_group["ph"][:]
-        _energies = cal_group["energy"][:]
-        _dph = cal_group["dph"][:]
-        _de = cal_group["de"][:]
-
-        for thisname, ph, e, dph, de in zip(_names, _ph, _energies, _dph, _de):
-            cal.add_cal_point(ph, e, thisname.decode(), dph, de)
-
-        return cal
-
-    def __repr__(self):
-        s = f"""mass.EnergyCalibration with {len(self._names)} entries
-        _ph: {self._ph}
-        _energies: {self._energies}
-        _names: {self._names}
-        _curvetype: {self._curvetype}
-        _use_approximation: {self._use_approximation}"""
-        return s

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -74,10 +74,10 @@ class EnergyCalibrationMaker:
     ValueError
         When calibration data arrays have unequal length, or `ph` is not monotone in `energy`.
     """
-    ph: np.ndarray[np.float64]
-    energy: np.ndarray[np.float64]
-    dph: np.ndarray[np.float64]
-    de: np.ndarray[np.float64]
+    ph: npt.NDArray[np.float64]
+    energy: npt.NDArray[np.float64]
+    dph: npt.NDArray[np.float64]
+    de: npt.NDArray[np.float64]
     names: list[str]
 
     @classmethod
@@ -395,10 +395,10 @@ class EnergyCalibrationMaker:
             curvename=curvename,
             approximating=approximate,
             spline=internal_spline,
+            energy2ph=energy2ph,
             ph2uncertainty=uncertainty_spline,
             input_transform=input_transform,
             output_transform=output_transform,
-            energy2ph=energy2ph
         )
 
     def drop_one_errors(self, curvename: str = "loglog",
@@ -436,18 +436,18 @@ class EnergyCalibration:
     ValueError
         _description_
     """
-    ph: np.ndarray[np.float64]
-    energy: np.ndarray[np.float64]
-    dph: np.ndarray[np.float64]
-    de: np.ndarray[np.float64]
+    ph: npt.NDArray[np.float64]
+    energy: npt.NDArray[np.float64]
+    dph: npt.NDArray[np.float64]
+    de: npt.NDArray[np.float64]
     names: list[str]
     curvename: str
     approximating: bool
     spline: Callable
+    energy2ph: Callable
     ph2uncertainty: Callable
     input_transform: Callable
     output_transform: Callable | None = None
-    energy2ph: Callable | None = None
 
     def __post_init__(self):
         assert self.npts > 0
@@ -612,7 +612,7 @@ class EnergyCalibration:
         cal_group.attrs['approximate'] = self.approximating
 
     @staticmethod
-    def load_from_hdf5(hdf5_group, name):
+    def load_from_hdf5(hdf5_group, name) -> EnergyCalibration:
         cal_group = hdf5_group[name]
 
         # Fix a behavior of h5py for writing in py2, reading in py3.
@@ -630,26 +630,26 @@ class EnergyCalibration:
         approximate = cal_group.attrs['approximate']
         return maker.make_calibration(curvetype, approximate=approximate)
 
-    def plotgain(self, **kwargs):
+    def plotgain(self, **kwargs) -> None:
         kwargs["plottype"] = "gain"
         self.plot(**kwargs)
 
-    def plotinvgain(self, **kwargs):
+    def plotinvgain(self, **kwargs) -> None:
         kwargs["plottype"] = "invgain"
         self.plot(**kwargs)
 
-    def plotloggain(self, **kwargs):
+    def plotloggain(self, **kwargs) -> None:
         kwargs["plottype"] = "loggain"
         self.plot(**kwargs)
 
     def plot(self, axis=None, color="blue", markercolor="red", plottype="linear", ph_rescale_power=0.0,  # noqa: PLR0917
-             removeslope=False, energy_x=False, showtext=True, showerrors=True, min_energy=None, max_energy=None):
+             removeslope=False, energy_x=False, showtext=True, showerrors=True, min_energy=None, max_energy=None) -> None:
         # Plot smooth curve
         minph, maxph = self.ph.min() * .9, self.ph.max() * 1.1
         if min_energy is not None:
-            minph = self.e2ph(min_energy)
+            minph = self.energy2ph(min_energy)
         if max_energy is not None:
-            maxph = self.e2ph(max_energy)
+            maxph = self.energy2ph(max_energy)
         phplot = np.linspace(minph, maxph, 1000)
         eplot = self(phplot)
         gplot = phplot / eplot

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -395,11 +395,11 @@ class EnergyCalibrationMaker:
         else:
             uncertainty_spline = np.zeros_like
 
-        ECalContructor = EnergyCalibration
+        ECalConstructor = EnergyCalibration
         if allow_attributes:
-            ECalContructor = EnergyCalibrationWithAttributes
+            ECalConstructor = EnergyCalibrationWithAttributes
 
-        return ECalContructor(
+        return ECalConstructor(
             self.ph, self.energy, self.dph, self.de, self.names,
             curvename=curvename,
             approximating=approximate,

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -604,7 +604,7 @@ class EnergyCalibration:
             del hdf5_group[name]
 
         cal_group = hdf5_group.create_group(name)
-        cal_group["name"] = [_name.encode() for _name in self.names]
+        cal_group["name"] = [str(n).encode() for n in self.names]
         cal_group["ph"] = self.ph
         cal_group["energy"] = self.energy
         cal_group["dph"] = self.dph

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -9,7 +9,11 @@ import numpy as np
 import pylab as plt
 import h5py
 import numpy.typing as npt
-from typing import Any, Self
+from typing import Any
+try:
+    from typing import Self
+except ImportError:
+    Self = "Self"
 from collections.abc import Callable
 import dataclasses
 from dataclasses import dataclass

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -357,7 +357,7 @@ class EnergyCalibrationMaker:
         elif len(x) > 1:
             internal_spline = CubicSplineFunction(x, y)
         else:
-            internal_spline = CubicSplineFunction(x*[1, 2], y*[1, 2])
+            internal_spline = CubicSplineFunction(x * [1, 2], y * [1, 2])
 
         ph_samplepoints = EnergyCalibrationMaker.heuristic_samplepoints(self.ph)
         E_samplepoints = output_transform(

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -326,8 +326,10 @@ class EnergyCalibrationMaker:
 
         if approximate:
             internal_spline = GPRSplineFunction(x, y, dy, dx)
-        else:
+        elif len(x) > 1:
             internal_spline = CubicSplineFunction(x, y)
+        else:
+            internal_spline = CubicSplineFunction(x*[1, 2], y*[1, 2])
 
         ph_samplepoints = EnergyCalibrationMaker.heuristic_samplepoints(self.ph)
         E_samplepoints = output_transform(

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -212,7 +212,7 @@ class EnergyCalibrationMaker:
             new_names[update_index] = name
         return EnergyCalibrationMaker(new_ph, new_energy, new_dph, new_de, new_names)
 
-    _ALLOWED_CURVNAMES = {
+    ALLOWED_CURVENAMES = {
         "linear", "linear+0", "loglog",
         "gain", "invgain", "loggain",
     }
@@ -247,8 +247,8 @@ class EnergyCalibrationMaker:
     def make_calibration(self, curvename="loglog", approximate=False, powerlaw=1.15):
         if approximate and self.npts < 3:
             raise ValueError(f"approximating curves require 3 or more cal anchor points, have {self.npts}")
-        if curvename not in self._ALLOWED_CURVNAMES:
-            raise ValueError(f"curvename='{curvename}', must be in {self._ALLOWED_CURVNAMES}")
+        if curvename not in self.ALLOWED_CURVENAMES:
+            raise ValueError(f"curvename='{curvename}', must be in {self.ALLOWED_CURVENAMES}")
 
         # Use a heuristic to repair negative uncertainties.
         def regularize_uncertainties(x):
@@ -265,14 +265,14 @@ class EnergyCalibrationMaker:
             input_transform = EnergyCalibration._ecal_input_log
             output_transform = EnergyCalibration._ecal_output_log
             x = np.log(self.ph)
-            y = np.log(self.energies)
+            y = np.log(self.energy)
             # When there's only one point, enhance it by a fake point to enforce power-law behavior
             if self.npts == 1:
                 arboffset = 1.0
                 x = np.hstack([x, x + arboffset])
                 y = np.hstack([y, y + arboffset / powerlaw])
-                dx = dph / self.ph
-                dy = de / self.energy
+            dx = dph / self.ph
+            dy = de / self.energy
 
         elif curvename == "gain":
             input_transform = EnergyCalibration._ecal_input_identity
@@ -301,7 +301,7 @@ class EnergyCalibrationMaker:
             y = self.energy
             dx = dph
             dy = de
-            if ("+0" in self.curvename()) and (0.0 not in x):
+            if ("+0" in curvename) and (0.0 not in x):
                 x = np.hstack(([0.0], x))
                 y = np.hstack(([0.0], y))
                 dx = np.hstack(([0.0], dx))

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -10,6 +10,7 @@ import pylab as plt
 import numpy.typing as npt
 # from typing import Optional
 from collections.abc import Callable
+import dataclasses
 from dataclasses import dataclass
 
 from mass.mathstat.interpolate import CubicSplineFunction, GPRSplineFunction
@@ -397,6 +398,9 @@ class EnergyCalibration:
 
     def __post_init__(self):
         assert self.npts > 0
+
+    def copy(self, **changes):
+        return dataclasses.replace(self, **changes)
 
     @property
     def npts(self):

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -282,6 +282,27 @@ class EnergyCalibrationMaker:
         x.append(anchors.max() * np.linspace(1, 2, 101)[1:])
         return np.hstack(x)
 
+    def make_calibration_loglog(
+            self, approximate: bool = False, powerlaw: float = 1.15, allow_attributes: bool = False) -> EnergyCalibration:
+        return self.make_calibration("loglog", approximate=approximate, powerlaw=powerlaw, allow_attributes=allow_attributes)
+
+    def make_calibration_gain(
+            self, approximate: bool = False, allow_attributes: bool = False) -> EnergyCalibration:
+        return self.make_calibration("gain", approximate=approximate, allow_attributes=allow_attributes)
+
+    def make_calibration_invgain(
+            self, approximate: bool = False, allow_attributes: bool = False) -> EnergyCalibration:
+        return self.make_calibration("invgain", approximate=approximate, allow_attributes=allow_attributes)
+
+    def make_calibration_loggain(
+            self, approximate: bool = False, allow_attributes: bool = False) -> EnergyCalibration:
+        return self.make_calibration("loggain", approximate=approximate, allow_attributes=allow_attributes)
+
+    def make_calibration_linear(
+            self, approximate: bool = False, addzero: bool = False, allow_attributes: bool = False) -> EnergyCalibration:
+        curvename = "linear+0" if addzero else "linear"
+        return self.make_calibration(curvename, approximate=approximate, allow_attributes=allow_attributes)
+
     def make_calibration(self, curvename: str = "loglog", approximate: bool = False,
                          powerlaw: float = 1.15, allow_attributes: bool = False) -> EnergyCalibration:
         if approximate and self.npts < 3:
@@ -626,7 +647,7 @@ class EnergyCalibration:
         cal_group.attrs['approximate'] = self.approximating
 
     @staticmethod
-    def load_from_hdf5(hdf5_group: h5py.Group, name: str) -> "EnergyCalibration":
+    def load_from_hdf5(hdf5_group: h5py.Group, name: str) -> EnergyCalibration:
         cal_group = hdf5_group[name]
 
         # Fix a behavior of h5py for writing in py2, reading in py3.

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -8,7 +8,11 @@ import numpy as np
 import pylab as plt
 import h5py
 import numpy.typing as npt
-from typing import Optional, Self, Any
+from typing import Optional, Any
+try:
+    from typing import Self
+except ImportError:
+    Self = "Self"
 from collections.abc import Callable
 import dataclasses
 from dataclasses import dataclass

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -574,7 +574,6 @@ class EnergyCalibration:
         cal_group["energy"] = self.energy
         cal_group["dph"] = self.dph
         cal_group["de"] = self.de
-        cal_group.attrs['nonlinearity'] = self.nonlinearity
         cal_group.attrs['curvetype'] = self.curvename
         cal_group.attrs['approximate'] = self.approximating
 
@@ -594,7 +593,6 @@ class EnergyCalibration:
             cal_group["de"][:],
             cal_group["name"][:]
         )
-        # powerlaw = cal_group.attrs['nonlinearity']
         approximate = cal_group.attrs['approximate']
         return maker.make_calibration(curvetype, approximate=approximate)
 

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -2,18 +2,19 @@
 Objects to assist with calibration from pulse heights to absolute energies.
 
 Created on May 16, 2011
+Completely redesigned January 2025
 """
 import numpy as np
 from scipy.optimize import brentq
-import numpy.typing as npt
-from typing import Optional
+import pylab as plt
+# import numpy.typing as npt
+# from typing import Optional
 from collections.abc import Callable
 from dataclasses import dataclass
 
 from mass.mathstat.interpolate import CubicSplineFunction, SmoothingSplineFunction, GPRSplineFunction
 from mass.mathstat.derivative import ExponentialFunction, Identity, LogFunction
 from mass.calibration.nist_xray_database import NISTXrayDBFile
-from ..common import isstr
 
 
 def LineEnergies():

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.optimize import brentq
 import pylab as plt
 import numpy.typing as npt
-# from typing import Optional
+from typing import Optional
 from collections.abc import Callable
 import dataclasses
 from dataclasses import dataclass
@@ -80,6 +80,30 @@ class EnergyCalibrationMaker:
     dph: np.ndarray[np.float64]
     de: np.ndarray[np.float64]
     names: list[str]
+
+    @classmethod
+    def init(cls,
+             ph: Optional[npt.ArrayLike] = None,
+             energy: Optional[npt.ArrayLike] = None,
+             dph: Optional[npt.ArrayLike] = None,
+             de: Optional[npt.ArrayLike] = None,
+             names: Optional[list] = None,
+             ):
+        if ph is None:
+            ph = np.array([], dtype=float)
+        if energy is None:
+            energy = np.array([], dtype=float)
+        if dph is None:
+            dph = 1e-3 * ph
+        if de is None:
+            de = 1e-3 * energy
+        if names is None:
+            names = ["dummy"] * len(dph)
+        ph = np.asarray(ph)
+        energy = np.asarray(energy)
+        dph = np.asarray(dph)
+        de = np.asarray(de)
+        return cls(ph, energy, dph, de, names)
 
     def __post_init__(self):
         """Check for inputs of unequal length. Check for monotone anchor points.

--- a/mass/calibration/energy_calibration.py
+++ b/mass/calibration/energy_calibration.py
@@ -4,15 +4,12 @@ Objects to assist with calibration from pulse heights to absolute energies.
 Created on May 16, 2011
 Completely redesigned January 2025
 """
+from __future__ import annotations
 import numpy as np
 import pylab as plt
 import h5py
 import numpy.typing as npt
-from typing import Optional, Any
-try:
-    from typing import Self
-except ImportError:
-    Self = "Self"
+from typing import Any, Self
 from collections.abc import Callable
 import dataclasses
 from dataclasses import dataclass
@@ -87,11 +84,11 @@ class EnergyCalibrationMaker:
 
     @classmethod
     def init(cls,
-             ph: Optional[npt.ArrayLike] = None,
-             energy: Optional[npt.ArrayLike] = None,
-             dph: Optional[npt.ArrayLike] = None,
-             de: Optional[npt.ArrayLike] = None,
-             names: Optional[list[str]] = None,
+             ph: npt.ArrayLike | None = None,
+             energy: npt.ArrayLike | None = None,
+             dph: npt.ArrayLike | None = None,
+             de: npt.ArrayLike | None = None,
+             names: list[str] | None = None,
              ) -> Self:
         if ph is None:
             ph = np.array([], dtype=float)
@@ -177,7 +174,7 @@ class EnergyCalibrationMaker:
         return self._remove_cal_point_idx(idxs[0]).remove_cal_point_energy(energy, de)
 
     def add_cal_point(self, ph: float, energy: float | str, name: str = "",
-                      ph_error: Optional[float] = None, e_error: Optional[float] = None,
+                      ph_error: float | None = None, e_error: float | None = None,
                       replace: bool = True) -> Self:
         """Add a single energy calibration point.
 
@@ -282,7 +279,7 @@ class EnergyCalibrationMaker:
         return np.hstack(x)
 
     def make_calibration(self, curvename: str = "loglog", approximate: bool = False,
-                         powerlaw: float = 1.15, allow_attributes: bool = False) -> "EnergyCalibration":
+                         powerlaw: float = 1.15, allow_attributes: bool = False) -> EnergyCalibration:
         if approximate and self.npts < 3:
             raise ValueError(f"approximating curves require 3 or more cal anchor points, have {self.npts}")
         if curvename not in self.ALLOWED_CURVENAMES:
@@ -656,7 +653,7 @@ class EnergyCalibration:
         self.plot(**kwargs)
 
     def plot(self,  # noqa: PLR0917
-             axis: Optional[plt.Axes] = None,
+             axis: plt.Axes | None = None,
              color: str = "blue",
              markercolor: str = "red",
              plottype: str = "linear",
@@ -665,8 +662,8 @@ class EnergyCalibration:
              energy_x: bool = False,
              showtext: bool = True,
              showerrors: bool = True,
-             min_energy: Optional[float] = None,
-             max_energy: Optional[float] = None) -> None:
+             min_energy: float | None = None,
+             max_energy: float | None = None) -> None:
         # Plot smooth curve
         minph, maxph = self.ph.min() * .9, self.ph.max() * 1.1
         if min_energy is not None:

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1859,13 +1859,10 @@ class MicrocalDataSet:  # noqa: PLR0904
             return self.calibration[calname]
 
         LOG.info("Calibrating chan %d to create %s", self.channum, calname)
-        cal = EnergyCalibration(curvname=curvetype)
-        cal.set_use_approximation(approximate)
-
         # It tries to calibrate detector using mass.calibration.algorithm.EnergyCalibrationAutocal.
-        auto_cal = EnergyCalibrationAutocal(cal,
-                                            getattr(self, attr)[self.cuts.good(**category)],
-                                            line_names)
+        auto_cal = EnergyCalibrationAutocal(
+            getattr(self, attr)[self.cuts.good(**category)],
+            line_names)
         auto_cal.guess_fit_params(smoothing_res_ph=size_related_to_energy_resolution,
                                   fit_range_ev=fit_range_ev,
                                   binsize_ev=bin_size_ev,
@@ -1879,6 +1876,7 @@ class MicrocalDataSet:  # noqa: PLR0904
                 "chan %d failed calibration because on of the fitter was a FailedFitter", self.channum)
             raise Exception()
 
+        cal = auto_cal.cal_factory.make_calibration(curvename=curvetype, approximate=approximate)
         self.calibration[calname] = cal
         hdf5_cal_group = self.hdf5_group.require_group('calibration')
         cal.save_to_hdf5(hdf5_cal_group, calname)

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1859,7 +1859,7 @@ class MicrocalDataSet:  # noqa: PLR0904
             return self.calibration[calname]
 
         LOG.info("Calibrating chan %d to create %s", self.channum, calname)
-        cal = EnergyCalibration(curvetype=curvetype)
+        cal = EnergyCalibration(curvname=curvetype)
         cal.set_use_approximation(approximate)
 
         # It tries to calibrate detector using mass.calibration.algorithm.EnergyCalibrationAutocal.

--- a/mass/mathstat/toeplitz.py
+++ b/mass/mathstat/toeplitz.py
@@ -138,6 +138,7 @@ class ToeplitzSolver:
             gsave = g[:K].copy()
             g[:K] -= g[K] * h[K - 1::-1]
             h[:K] -= h[K] * gsave[K - 1::-1]
+        raise ValueError("unreachable")
 
     def __precompute_symmetric(self):
         """Precompute some data so that the solve_symmetric method can be done in
@@ -161,6 +162,7 @@ class ToeplitzSolver:
             g[K] = ((self.T[K:0:-1] * g[:K]).sum() - self.T[K + 1]) / self.xg_denom[K]
             self.gK_leading[K] = g[K]
             g[:K] -= g[K] * g[K - 1::-1]
+        raise ValueError("unreachable")
 
     def __solve_symmetric(self, y: npt.ArrayLike) -> np.ndarray:
         """Return the solution x when Tx=y for a symmetric Toeplitz matrix T."""
@@ -193,3 +195,4 @@ class ToeplitzSolver:
             # Steps e and f
             g[K] = self.gK_leading[K]
             g[:K] -= g[K] * g[K - 1::-1]
+        raise ValueError("unreachable")

--- a/mass/off/channels.py
+++ b/mass/off/channels.py
@@ -539,17 +539,17 @@ class Channel(CorG):  # noqa: PLR0904
     def learnPhaseCorrection(self, indicatorName="filtPhase", uncorrectedName="filtValue", correctedName=None, states=None,
                              linePositionsFunc=None, cutRecipeName=None, overwriteRecipe=False):
         """
-        linePositionsFunc - if None, then use self.calibrationRough._ph as the peak locations
+        linePositionsFunc - if None, then use self.calibrationRough.ph as the peak locations
         otherwise try to call it with self as an argument...
         Here is an example of how you could use all but one peak from calibrationRough:
-        `data.learnPhaseCorrection(linePositionsFunc = lambda ds: ds.recipes["energyRough"].f._ph`
+        `data.learnPhaseCorrection(linePositionsFunc = lambda ds: ds.recipes["energyRough"].f.ph`
         """
         # may need to generalize this to allow using a specific state for phase correction as
         # a specfic line... with something like calibrationPlan
         if correctedName is None:
             correctedName = uncorrectedName + "PC"
         if linePositionsFunc is None:
-            linePositions = self.recipes["energyRough"].f._ph
+            linePositions = self.recipes["energyRough"].f.ph
         else:
             linePositions = linePositionsFunc(self)
         indicator, uncorrected = self.getAttr(

--- a/mass/off/channels.py
+++ b/mass/off/channels.py
@@ -625,9 +625,9 @@ class Channel(CorG):  # noqa: PLR0904
             line = mass.SpectralLine.quick_monochromatic_line(name, energy, 0.001, 0)
         self.calibrationPlan.addCalPoint(uncalibratedVal, states, line)
         calibrationRough = self.calibrationPlan.getRoughCalibration()
-        calibrationRough.uncalibratedName = self.calibrationPlanAttr
+        uncalibratedName = self.calibrationPlanAttr
         self.recipes.add("energyRough", calibrationRough,
-                         [calibrationRough.uncalibratedName], inverse=calibrationRough.energy2ph, overwrite=True)
+                         [uncalibratedName], inverse=calibrationRough.energy2ph, overwrite=True)
         return self.calibrationPlan
 
     @add_group_loop
@@ -1089,10 +1089,9 @@ class CalibrationPlan:
         return s
 
     def getRoughCalibration(self):
-        cal = mass.EnergyCalibration(curvetype="gain")
-        for (x, y, name) in zip(self.uncalibratedVals, self.energies, self.names):
-            cal.add_cal_point(x, y, name)
-        return cal
+        zero = np.zeros_like(self.energies)
+        factory = mass.EnergyCalibrationMaker(self.uncalibratedVals, self.energies, zero, zero, self.names)
+        return factory.make_calibration(curvename="gain")
 
 
 def getOffFileListFromOneFile(filename, maxChans=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ mass = [
 
 [tool.setuptools_scm]
 version_file = "mass/_version.py"
+
+[tool.mypy]
+disable_error_code = ["import-untyped"]

--- a/tests/calibration/test_algorithms.py
+++ b/tests/calibration/test_algorithms.py
@@ -41,11 +41,10 @@ def test_find_local_maxima():
 
 def test_build_fit_ranges():
     known_energies = np.array([1000, 2000, 2050, 3000])
-    # make a 1 to 10 calibration
-    cal1 = mass.energy_calibration.EnergyCalibration(1, approximate=False)
-    for ke in known_energies:
-        # args are (pulseheight, energy)
-        cal1.add_cal_point(0.1 * ke, ke)
+    z = np.zeros_like(known_energies)
+    names = ["dummy"] * len(z)
+    factory = mass.EnergyCalibrationMaker(0.1*known_energies, known_energies, z, z, names)
+    cal1 = factory.make_calibration(approximate=False)
 
     # this call asks for fit ranges at each known energy, and asks to avoid the line at 3050,
     # uses cal1 for the apprixmate calibraiton and asks for 100 eV wide fit ranges
@@ -68,11 +67,10 @@ def test_build_fit_ranges():
 
 def test_build_fit_ranges_ph():
     known_energies = np.array([1000, 2000, 2050, 3000])
-    # make a 1 to 10 calibration
-    cal1 = mass.energy_calibration.EnergyCalibration(1, approximate=False)
-    for ke in known_energies:
-        # args are (pulseheight, energy)
-        cal1.add_cal_point(0.1 * ke, ke)
+    z = np.zeros_like(known_energies)
+    names = ["dummy"] * len(z)
+    factory = mass.EnergyCalibrationMaker(0.1*known_energies, known_energies, z, z, names)
+    cal1 = factory.make_calibration(approximate=False)
 
     # this call asks for fit ranges at each known energy, and asks to avoid the line at 3050,
     # uses cal1 for the apprixmate calibraiton and asks for 100 eV wide fit ranges
@@ -110,10 +108,12 @@ def test_complete():
     line_names = ["MnKAlpha", "MnKBeta", "CuKAlpha", "TiKAlpha", "FeKAlpha"]
 
     _names_e, energies_opt, ph_opt = find_opt_assignment(lm, line_names)
+    ph_opt = np.asarray(ph_opt)
+    energies_opt = np.asanyarray(energies_opt)
 
-    approxcal = mass.energy_calibration.EnergyCalibration(1, approximate=False)
-    for (ee, phph) in zip(energies_opt, ph_opt):
-        approxcal.add_cal_point(phph, ee)
+    z = np.zeros_like(energies_opt)
+    factory = mass.EnergyCalibrationMaker(ph_opt, energies_opt, z, z, line_names)
+    approxcal = factory.make_calibration(approximate=False)
 
     _energies, fit_lo_hi, slopes_de_dph = build_fit_ranges_ph(energies_opt, [], approxcal, 100)
     binsize_ev = 1.0

--- a/tests/calibration/test_algorithms.py
+++ b/tests/calibration/test_algorithms.py
@@ -65,7 +65,7 @@ def test_build_fit_ranges():
 
 def test_build_fit_ranges_ph():
     known_energies = np.array([1000, 2000, 2050, 3000])
-    factory = mass.EnergyCalibrationMaker.init(0.1*known_energies, known_energies)
+    factory = mass.EnergyCalibrationMaker.init(0.1 * known_energies, known_energies)
     cal1 = factory.make_calibration(approximate=False)
 
     # this call asks for fit ranges at each known energy, and asks to avoid the line at 3050,

--- a/tests/calibration/test_algorithms.py
+++ b/tests/calibration/test_algorithms.py
@@ -41,9 +41,7 @@ def test_find_local_maxima():
 
 def test_build_fit_ranges():
     known_energies = np.array([1000, 2000, 2050, 3000])
-    z = np.zeros_like(known_energies)
-    names = ["dummy"] * len(z)
-    factory = mass.EnergyCalibrationMaker(0.1*known_energies, known_energies, z, z, names)
+    factory = mass.EnergyCalibrationMaker.init(0.1 * known_energies, known_energies)
     cal1 = factory.make_calibration(approximate=False)
 
     # this call asks for fit ranges at each known energy, and asks to avoid the line at 3050,
@@ -67,9 +65,7 @@ def test_build_fit_ranges():
 
 def test_build_fit_ranges_ph():
     known_energies = np.array([1000, 2000, 2050, 3000])
-    z = np.zeros_like(known_energies)
-    names = ["dummy"] * len(z)
-    factory = mass.EnergyCalibrationMaker(0.1*known_energies, known_energies, z, z, names)
+    factory = mass.EnergyCalibrationMaker.init(0.1*known_energies, known_energies)
     cal1 = factory.make_calibration(approximate=False)
 
     # this call asks for fit ranges at each known energy, and asks to avoid the line at 3050,

--- a/tests/calibration/test_algorithms.py
+++ b/tests/calibration/test_algorithms.py
@@ -6,7 +6,7 @@ from pytest import approx
 import numpy as np
 import mass
 from mass.calibration.algorithms import find_opt_assignment, find_local_maxima, build_fit_ranges, \
-    build_fit_ranges_ph, multifit, EnergyCalibration, EnergyCalibrationAutocal
+    build_fit_ranges_ph, multifit, EnergyCalibrationAutocal
 import itertools
 
 rng = np.random.default_rng(2)
@@ -130,12 +130,10 @@ def test_autocal():
     e = e[e > 0]   # The wide-tailed distributions will occasionally produce negative e. Bad!
     ph = 2 * e**0.9
 
-    cal = EnergyCalibration()
-    auto_cal = EnergyCalibrationAutocal(cal, ph, line_names)
+    auto_cal = EnergyCalibrationAutocal(ph, line_names)
     auto_cal.autocal()
     auto_cal.diagnose()
-    cal.diagnose()
-    assert hasattr(cal, "autocal")
+
     # test fitters are correct type, and ordered by line energy
     e0 = 0
     for r in auto_cal.results:

--- a/tests/calibration/test_calibration.py
+++ b/tests/calibration/test_calibration.py
@@ -20,10 +20,7 @@ def basic_nonlinearity(e: np.ndarray) -> np.ndarray:
 def basic_factory(npoints=10):
     energy = np.linspace(3000, 6000, npoints)
     ph = basic_nonlinearity(energy)
-    dph = ph * 1e-3
-    de = energy * 1e-3
-    names = ["dummy"] * npoints
-    return EnergyCalibrationMaker(ph, energy, dph, de, names)
+    return EnergyCalibrationMaker.init(ph, energy)
 
 
 def compare_curves(curvetype1, use_approximation1, curvetype2, use_approximation2, npoints=10):
@@ -253,8 +250,7 @@ class TestJoeStyleEnergyCalibration:
                         0.22199391, 0.54440676, 0.26877157, 2.36176241, 1.74482802])
         de = np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01,
                        0.01, 0.01, 0.01, 0.01])
-        names = ["dummy"] * len(ph)
-        factory = mass.EnergyCalibrationMaker(ph, e, dph, de, names)
+        factory = mass.EnergyCalibrationMaker.init(ph, e, dph, de)
         cal = factory.make_calibration(curvename="gain", approximate=True)
         assert (np.abs(cal(ph) - e) < 0.9 * dph).all()
 

--- a/tests/calibration/test_calibration.py
+++ b/tests/calibration/test_calibration.py
@@ -13,15 +13,21 @@ import os
 from mass import EnergyCalibrationMaker
 
 
-def compare_curves(curvetype1, use_approximation1, curvetype2, use_approximation2, npoints=10):
-    energy = np.linspace(3000, 6000, npoints)
+def basic_nonlinearity(e: np.ndarray) -> np.ndarray:
+    return e**0.8
 
-    def e2ph(e):
-        return e**0.8
-    ph = e2ph(energy)
-    dph = de = np.zeros_like(ph)
-    names = npoints * ["dummy"]
-    factory = EnergyCalibrationMaker(ph, energy, dph, de, names)
+
+def basic_factory(npoints=10):
+    energy = np.linspace(3000, 6000, npoints)
+    ph = basic_nonlinearity(energy)
+    dph = ph * 1e-3
+    de = energy * 1e-3
+    names = ["dummy"] * npoints
+    return EnergyCalibrationMaker(ph, energy, dph, de, names)
+
+
+def compare_curves(curvetype1, use_approximation1, curvetype2, use_approximation2, npoints=10):
+    factory = basic_factory()
     cal1 = factory.make_calibration(curvetype1, use_approximation1)
     cal2 = factory.make_calibration(curvetype2, use_approximation2)
 
@@ -30,8 +36,8 @@ def compare_curves(curvetype1, use_approximation1, curvetype2, use_approximation
     refenergy = 5100.0
     ph1 = cal1.energy2ph(refenergy)
     ph2 = cal2.energy2ph(refenergy)
-    e1 = cal1.ph2energy(e2ph(refenergy))
-    e2 = cal2.ph2energy(e2ph(refenergy))
+    e1 = cal1.ph2energy(basic_nonlinearity(refenergy))
+    e2 = cal2.ph2energy(basic_nonlinearity(refenergy))
     doe1 = factory.drop_one_errors(curvetype1, use_approximation1)
     doe2 = factory.drop_one_errors(curvetype2, use_approximation2)
     return ph1, e1, doe1, ph2, e2, doe2, cal1, cal2
@@ -54,19 +60,6 @@ class TestLineDatabase:
         for element in ("U", "Pr", "Ar", "Pt", "Au", "Hg"):
             assert E[f"{element}KAlpha"] > 0.0
         assert E["MnKAlpha1"] > E["MnKAlpha2"]
-
-
-def basic_nonlinearity(e: np.ndarray) -> np.ndarray:
-    return e**0.8
-
-
-def basic_factory(npoints=10):
-    energy = np.linspace(3000, 6000, npoints)
-    ph = basic_nonlinearity(energy)
-    dph = ph * 1e-3
-    de = energy * 1e-3
-    names = [""] * npoints
-    return EnergyCalibrationMaker(ph, energy, dph, de, names)
 
 
 @pytest.mark.filterwarnings("ignore:divide by zero encountered")
@@ -165,7 +158,7 @@ class TestJoeStyleEnergyCalibration:
     def test_gain_loglog_2pts():
         ph1, e1, (_drop1e, drop1err), ph2, e2, (_drop2e, drop2err), _cal1, _cal2 = compare_curves(
             curvetype1="gain", use_approximation1=True,
-            curvetype2="loglog", use_approximation2=False, npoints=2)
+            curvetype2="loglog", use_approximation2=False, npoints=3)
         assert ph1 != ph2
         assert e1 != e2
         assert not all(drop1err == drop2err)
@@ -194,59 +187,54 @@ class TestJoeStyleEnergyCalibration:
         dph = ph * 1e-3
         de = energy * 1e-3
         names = len(ph) * [""]
-        maker = EnergyCalibrationMaker(ph, energy, dph, de, names)
-        cal1 = maker.make_calibration("gain", True)
+        factory = EnergyCalibrationMaker(ph, energy, dph, de, names)
+        assert np.all(np.diff(factory.ph) > 0)
+        cal1 = factory.make_calibration("gain", True)
         cal1(np.array([2200, 4200, 4400], dtype=float))
 
     @staticmethod
     def test_nonmonotonic_fail():
         "Check that issue 216 is fixed: non-monotone {E,PH} pairs should cause exceptions."
-        cal1 = mass.calibration.energy_calibration.EnergyCalibration()
-        cal1.set_curvetype("gain")
-        cal1.set_use_approximation(True)
-        energies = np.array([6000, 3000, 4500, 4000], dtype=float)
-        phvec = np.array([3000, 6000, 4500, 5000], dtype=float)
+        energy = np.array([6000, 3000, 4500, 4000], dtype=float)
+        ph = np.array([3000, 6000, 4500, 5000], dtype=float)
+        dph = ph * 1e-3
+        de = energy * 1e-3
+        names = len(ph) * [""]
         with pytest.raises(Exception):
-            for ph, energy in zip(phvec, energies):
-                cal1.add_cal_point(ph, energy)
+            factory = EnergyCalibrationMaker(ph, energy, dph, de, names)
+            factory.make_calibration(curvename="gain", approximate=True)
 
     @staticmethod
     def test_save_and_load_to_hdf5():
-        cal1 = mass.calibration.energy_calibration.EnergyCalibration()
-        for energy in np.linspace(3000, 6000, 10):
-            ph = energy**0.8
-            cal1.add_cal_point(ph, energy)
+        factory = basic_factory()
         fname = "to_be_deleted.hdf5"
-        for ctype in (0, "gain"):
-            cal1.set_curvetype(ctype)
+        for ctype in ("loglog", "gain"):
+            cal1 = factory.make_calibration(curvename=ctype)
             with h5py.File(fname, "w") as h5:
                 grp = h5.require_group("calibration")
                 cal1.save_to_hdf5(grp, "cal1")
-                cal2 = mass.calibration.energy_calibration.EnergyCalibration.load_from_hdf5(
-                    grp, "cal1")
+                cal2 = mass.EnergyCalibration.load_from_hdf5(grp, "cal1")
                 assert len(grp.keys()) == 1
-            assert all(cal1._ph == cal2._ph)
-            assert all(cal2._energies == cal2._energies)
-            assert all(cal1._dph == cal2._dph)
-            assert all(cal1._de == cal2._de)
-            assert cal1.nonlinearity == cal2.nonlinearity
-            assert cal1.CURVETYPE == cal2.CURVETYPE
-            assert cal1._use_approximation == cal2._use_approximation
+            assert all(cal1.ph == cal2.ph)
+            assert all(cal2.energy == cal2.energy)
+            assert all(cal1.dph == cal2.dph)
+            assert all(cal1.de == cal2.de)
+            assert cal1.curvename == cal2.curvename
+            assert cal1.approximating == cal2.approximating
             os.remove(fname)
 
     @staticmethod
     def test_negative_inputs():
-        """Negative or zero pulse-heights shouldn't produce NaN or Inf energies."""
-        cal = mass.calibration.energy_calibration.EnergyCalibration()
-        for energy in np.linspace(3000, 6000, 10):
-            ph = basic_nonlinearity(energy)
-            cal.add_cal_point(ph, energy)
-        cal.set_use_approximation(True)
+        """Negative or zero pulse-heights shouldn't produce NaN or Inf energies, except in loglog cal."""
+        factory = basic_factory()
 
         ph = np.arange(-10, 10, dtype=float) * 1000.
-        for ct in cal.CURVETYPE:
-            cal.set_curvetype(ct)
+        for ct in EnergyCalibrationMaker.ALLOWED_CURVENAMES:
+            if ct == "loglog":
+                continue
+            cal = factory.make_calibration(ct, approximate=True)
             e = cal(ph)
+            print(ct, e)
             assert not any(np.isnan(e))
             assert not any(np.isinf(e))
 
@@ -265,24 +253,16 @@ class TestJoeStyleEnergyCalibration:
                         0.22199391, 0.54440676, 0.26877157, 2.36176241, 1.74482802])
         de = np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01,
                        0.01, 0.01, 0.01, 0.01])
-        cal1 = mass.EnergyCalibration(curvetype="gain", approximate=True, useGPR=False)
-        cal2 = mass.EnergyCalibration(curvetype="gain", approximate=True, useGPR=True)
-        for cal in (cal1, cal2):
-            for a, b, c, d in zip(ph, e, dph, de):
-                cal.add_cal_point(a, b, pht_error=c, e_error=d, name=f"{b:.3f} eV")
-            cal._update_converters()
-        assert (np.abs(cal1(ph) - e) < 1.2 * dph).all()
-        assert (np.abs(cal2(ph) - e) < 0.7 * dph).all()
-
-        # Be sure that the old-style (non-GPR) spline finds the right curvature
-        assert cal1._underlying_spline.actualchisq == pytest.approx(len(ph), abs=0.01)
+        names = ["dummy"] * len(ph)
+        factory = mass.EnergyCalibrationMaker(ph, e, dph, de, names)
+        cal = factory.make_calibration(curvename="gain", approximate=True)
+        assert (np.abs(cal(ph) - e) < 0.9 * dph).all()
 
         # Test for a problem in extrapolated gain that I had: gain was extrapolated with zero slope!
-        for cal in (cal1, cal2):
-            g1k = 10000 / cal(10000)
-            g4k = 40000 / cal(40000)
-            assert g1k > 3.2
-            assert g4k < 2.9
+        g1k = 10000 / cal(10000)
+        g4k = 40000 / cal(40000)
+        assert g1k > 3.2
+        assert g4k < 2.9
 
     @staticmethod
     def test_monotonic():
@@ -292,10 +272,9 @@ class TestJoeStyleEnergyCalibration:
         ph1 = e * 10 / (1 + e / 2500)
         ph2 = ph1.copy()
         ph2[5] *= (ph2[5] / ph2[4])**(-0.85)
-        cal1 = mass.EnergyCalibration(curvetype="gain")
-        cal2 = mass.EnergyCalibration(curvetype="gain")
-        for p1, p2, n in zip(ph1, ph2, names):
-            cal1.add_cal_point(p1, n, pht_error=p1 * 1e-4)
-            cal2.add_cal_point(p2, n, pht_error=p2 * 1e-4)
+        factory1 = mass.EnergyCalibrationMaker(ph1, e, ph1 * 1e-4, np.zeros_like(e), names)
+        factory2 = mass.EnergyCalibrationMaker(ph2, e, ph2 * 1e-4, np.zeros_like(e), names)
+        cal1 = factory1.make_calibration("gain")
+        cal2 = factory2.make_calibration("gain")
         assert cal1.ismonotonic
         assert not cal2.ismonotonic

--- a/tests/mathstat/test_interpolation.py
+++ b/tests/mathstat/test_interpolation.py
@@ -32,8 +32,7 @@ class Test_SmoothingSpline:
         # At time of issue #74, this crashed on next line for Joe, but not for Galen.
         mass.mathstat.interpolate.SmoothingSplineLog(ph, e, de, dph)
 
-        names = len(e) * ["dummy"]
-        cal = mass.EnergyCalibrationMaker(e**0.8, e, dph, de, names)
+        cal = mass.EnergyCalibrationMaker.init(e**0.8, e, dph, de)
         # At time of issue #74, this crashed on next line for Galen, but not for Joe.
         cal.drop_one_errors()
 

--- a/tests/mathstat/test_interpolation.py
+++ b/tests/mathstat/test_interpolation.py
@@ -32,10 +32,8 @@ class Test_SmoothingSpline:
         # At time of issue #74, this crashed on next line for Joe, but not for Galen.
         mass.mathstat.interpolate.SmoothingSplineLog(ph, e, de, dph)
 
-        cal = mass.calibration.energy_calibration.EnergyCalibration()
-        for energy in np.linspace(3000, 6000, 10):
-            ph = energy**0.8
-            cal.add_cal_point(ph, energy)
+        names = len(e) * ["dummy"]
+        cal = mass.EnergyCalibrationMaker(e**0.8, e, dph, de, names)
         # At time of issue #74, this crashed on next line for Galen, but not for Joe.
         cal.drop_one_errors()
 

--- a/tests/off/test_5lag_off.py
+++ b/tests/off/test_5lag_off.py
@@ -90,7 +90,7 @@ def test_off_5lag_with_saving_and_loading_recipes(tmp_path):
     assert all(data[3].filtValue5LagDCPC == data2[3].filtValue5LagDCPC)
     assert all(data[3].cutResidualStdDev == data2[3].cutResidualStdDev)
     assert data[3].recipes["energy"].f.uncalibratedName == data2[3].recipes["energy"].f.uncalibratedName
-    assert data[3].recipes["energy"].f._names == data2[3].recipes["energy"].f._names
+    assert data[3].recipes["energy"].f.names == data2[3].recipes["energy"].f.names
 
     data3 = mass.off.ChannelGroup(off_filenames)
     data3[3].learnCalibrationPlanFromEnergiesAndPeaks(


### PR DESCRIPTION
Use frozen dataclasses to hold:
1.  `EnergyCalibration` objects that perform calibration curves with fixed set of anchor points, fixed mathematical transformations (e.g., "loglog"), and fixed approximation or exact interpolation.
2. `EnergyCalibrationMaker` objects that hold a set of calibration anchor points (with uncertainties and names), able to generate an `EnergyCalibration` with any fixed transformation and approximation/exact choice.

The API for using these has changed as little as possible, but it has changed. You use:
- `EnergyCalibrationMaker.init()` when you want to start with default values for the pulse height and/or energy uncertainties, and possibly dummy names for the anchor points.
- `maker.add_cal_point(...)` to create a maker with one new cal point added, and similarly for dropping 1 or more cal points.
- `EnergyCalibrationMaker.drop_one_errors()` to get the set of drop-1 errors.
- But most other familiar methods are methods not of the `EnergyCalibrationMaker` but of the specific `EnergyCalibration`, such as `.plot(...)` or `ph2dedph(...)` and so forth.