### PR TITLE
Add option to use improved 'flux jump correction' algorithm

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 
 * Make Fourier-domain optimal filters work (issue 320).
 * Add doctests for the new filtering API (issue 323).
+* Add Thomas Baker's improved method for correcting jumps by 1 (or more) flux quanta (PR 325).
 
 **0.8.7** January 24, 2025
 

--- a/mass/core/analysis_algorithms.py
+++ b/mass/core/analysis_algorithms.py
@@ -415,7 +415,7 @@ def filter_signal_lowpass(sig, fs, fcut):
     return sig_filt
 
 
-def correct_flux_jumps(vals, g, flux_quant, algorithm):
+def correct_flux_jumps_original(vals, g, flux_quant):
     '''Remove 'flux' jumps' from pretrigger mean.
 
     When using umux readout, if a pulse is recorded that has a very fast rising
@@ -434,30 +434,49 @@ def correct_flux_jumps(vals, g, flux_quant, algorithm):
     Returns:
     Array with values corrected
     '''
-    if algorithm == "orig":
-        # The naive thing is to simply replace each value with its value mod
-        # the flux quantum. But of the baseline value turns out to fluctuate
-        # about an integer number of flux quanta, this will introduce new
-        # jumps. I don't know the best way to handle this in general. For now,
-        # if there are still jumps after the mod, I add 1/4 of a flux quanta
-        # before modding, then mod, then subtract the 1/4 flux quantum and then
-        # *add* a single flux quantum so that the values never go negative.
-        #
-        # To determine whether there are "still jumps after the mod" I look at the
-        # difference between the largest and smallest values for "good" pulses. If
-        # you don't exclude "bad" pulses, this check can be tricked in cases where
-        # the pretrigger section contains a (sufficiently large) tail.
-        if (np.amax(vals) - np.amin(vals)) >= flux_quant:
-            corrected = vals % (flux_quant)
-            if (np.amax(corrected[g]) - np.amin(corrected[g])) > 0.75 * flux_quant:
-                corrected = (vals + flux_quant / 4) % (flux_quant)
-                corrected = corrected - flux_quant / 4 + flux_quant
-            corrected -= (corrected[0] - vals[0])
-            return corrected
-        else:
-            return vals
+    # The naive thing is to simply replace each value with its value mod
+    # the flux quantum. But of the baseline value turns out to fluctuate
+    # about an integer number of flux quanta, this will introduce new
+    # jumps. I don't know the best way to handle this in general. For now,
+    # if there are still jumps after the mod, I add 1/4 of a flux quanta
+    # before modding, then mod, then subtract the 1/4 flux quantum and then
+    # *add* a single flux quantum so that the values never go negative.
+    #
+    # To determine whether there are "still jumps after the mod" I look at the
+    # difference between the largest and smallest values for "good" pulses. If
+    # you don't exclude "bad" pulses, this check can be tricked in cases where
+    # the pretrigger section contains a (sufficiently large) tail.
+    if (np.amax(vals) - np.amin(vals)) >= flux_quant:
+        corrected = vals % (flux_quant)
+        if (np.amax(corrected[g]) - np.amin(corrected[g])) > 0.75 * flux_quant:
+            corrected = (vals + flux_quant / 4) % (flux_quant)
+            corrected = corrected - flux_quant / 4 + flux_quant
+        corrected -= (corrected[0] - vals[0])
+        return corrected
     else:
-        return unwrap_n(vals, flux_quant)
+        return vals
+
+
+def correct_flux_jumps(vals, _mask_ignore, flux_quant):
+    '''Remove 'flux' jumps' from pretrigger mean.
+
+    When using umux readout, if a pulse is recorded that has a very fast rising
+    edge (e.g. a cosmic ray), the readout system will "slip" an integer number
+    of flux quanta. This means that the baseline level returned to after the
+    pulse will different from the pretrigger value by an integer number of flux
+    quanta. This causes that pretrigger mean summary quantity to jump around in
+    a way that causes trouble for the rest of MASS. This function attempts to
+    correct these jumps.
+
+    Arguments:
+    vals -- array of values to correct
+    g -- mask indentifying "good" pulses
+    flux_quant -- size of 1 flux quanta
+
+    Returns:
+    Array with values corrected
+    '''
+    return unwrap_n(vals, flux_quant)
 
 
 @njit

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1568,7 +1568,7 @@ class MicrocalDataSet:  # noqa: PLR0904
         self.cuts.clear_cut()
         self.saved_auto_cuts = None
 
-    def correct_flux_jumps(self, flux_quant):
+    def correct_flux_jumps(self, flux_quant, algorithm="orig"):
         '''Remove 'flux' jumps' from pretrigger mean.
 
         When using umux readout, if a pulse is recorded that has a very fast
@@ -1585,7 +1585,7 @@ class MicrocalDataSet:  # noqa: PLR0904
         # remember original value, just in case we need it
         self.p_pretrig_mean_orig = self.p_pretrig_mean[:]
         corrected = mass.core.analysis_algorithms.correct_flux_jumps(
-            self.p_pretrig_mean[:], self.good(), flux_quant)
+            self.p_pretrig_mean[:], self.good(), flux_quant, algorithm=algorithm)
         self.p_pretrig_mean[:] = corrected
 
     @_add_group_loop()

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1568,7 +1568,7 @@ class MicrocalDataSet:  # noqa: PLR0904
         self.cuts.clear_cut()
         self.saved_auto_cuts = None
 
-    def correct_flux_jumps(self, flux_quant, algorithm="orig"):
+    def correct_flux_jumps(self, flux_quant, algorithm="Baker"):
         '''Remove 'flux' jumps' from pretrigger mean.
 
         When using umux readout, if a pulse is recorded that has a very fast
@@ -1581,11 +1581,14 @@ class MicrocalDataSet:  # noqa: PLR0904
 
         Arguments:
         flux_quant -- size of 1 flux quantum
+        algorithm -- {"Baker", "orig"}
         '''
-        # remember original value, just in case we need it
-        self.p_pretrig_mean_orig = self.p_pretrig_mean[:]
-        corrected = mass.core.analysis_algorithms.correct_flux_jumps(
-            self.p_pretrig_mean[:], self.good(), flux_quant, algorithm=algorithm)
+        methods = {
+            "Baker": mass.core.analysis_algorithms.correct_flux_jumps,
+            "orig": mass.core.analysis_algorithms.correct_flux_jumps_original
+        }
+        method = methods[algorithm]
+        corrected = method(self.p_pretrig_mean[:], self.good(), flux_quant)
         self.p_pretrig_mean[:] = corrected
 
     @_add_group_loop()

--- a/mass/core/channel.py
+++ b/mass/core/channel.py
@@ -1568,6 +1568,7 @@ class MicrocalDataSet:  # noqa: PLR0904
         self.cuts.clear_cut()
         self.saved_auto_cuts = None
 
+    @_add_group_loop()
     def correct_flux_jumps(self, flux_quant, algorithm="Baker"):
         '''Remove 'flux' jumps' from pretrigger mean.
 

--- a/mass/core/channel_group.py
+++ b/mass/core/channel_group.py
@@ -1155,7 +1155,7 @@ class TESGroup(CutFieldMixin, GroupLooper):  # noqa: PLR0904, PLR0917
                 ltext = axis.get_legend().get_texts()
                 plt.setp(ltext, fontsize='small')
 
-    def correct_flux_jumps(self, flux_quant):
+    def correct_flux_jumps(self, flux_quant, algorithm="orig"):
         '''Remove 'flux' jumps' from pretrigger mean.
 
         When using umux readout, if a pulse is recorded that has a very fast
@@ -1171,7 +1171,7 @@ class TESGroup(CutFieldMixin, GroupLooper):  # noqa: PLR0904, PLR0917
         '''
         for ds in self:
             try:
-                ds.correct_flux_jumps(flux_quant)
+                ds.correct_flux_jumps(flux_quant, algorithm=algorithm)
             except Exception:
                 self.set_chan_bad(ds.channum, "failed to correct flux jumps")
 

--- a/mass/core/channel_group.py
+++ b/mass/core/channel_group.py
@@ -1155,26 +1155,6 @@ class TESGroup(CutFieldMixin, GroupLooper):  # noqa: PLR0904, PLR0917
                 ltext = axis.get_legend().get_texts()
                 plt.setp(ltext, fontsize='small')
 
-    def correct_flux_jumps(self, flux_quant, algorithm="orig"):
-        '''Remove 'flux' jumps' from pretrigger mean.
-
-        When using umux readout, if a pulse is recorded that has a very fast
-        rising edge (e.g. a cosmic ray), the readout system will "slip" an
-        integer number of flux quanta. This means that the baseline level
-        returned to after the pulse will different from the pretrigger value by
-        an integer number of flux quanta. This causes that pretrigger mean
-        summary quantity to jump around in a way that causes trouble for the
-        rest of MASS. This function attempts to correct these jumps.
-
-        Arguments:
-        flux_quant -- size of 1 flux quantum
-        '''
-        for ds in self:
-            try:
-                ds.correct_flux_jumps(flux_quant, algorithm=algorithm)
-            except Exception:
-                self.set_chan_bad(ds.channum, "failed to correct flux jumps")
-
     def sanitize_p_filt_phase(self):
         self.register_boolean_cut_fields("filt_phase")
         for ds in self:

--- a/tests/core/test_flux_jump_correction.py
+++ b/tests/core/test_flux_jump_correction.py
@@ -1,0 +1,59 @@
+import numpy as np
+from mass.core.analysis_algorithms import unwrap_n
+
+import logging
+LOG = logging.getLogger("mass")
+
+rng = np.random.default_rng(7923532)  # make tests not fail randomly
+
+
+class Test_unwrap_n:
+
+    def setup_method(self):
+        self.noise_size = 10.0
+        self.dlength = 1000
+        self.data = rng.uniform(size=self.dlength) * self.noise_size
+
+    def test_no_unwrap(self):
+        unwrapped = unwrap_n(self.data, self.noise_size / 10, n=0)
+        assert np.array_equal(unwrapped, self.data)
+
+    def test_period_limits(self):
+        max_diff = np.max(np.abs(np.diff(self.data)))
+        # Pick a period to ensure that at least one point should move
+        period = max_diff * 1.99
+        unwrapped = unwrap_n(self.data, period, n=1)
+        assert not np.array_equal(unwrapped, self.data)
+
+        # Should do nothing
+        period = max_diff * 2.01
+        unwrapped = unwrap_n(self.data, period, n=1)
+        assert np.array_equal(unwrapped, self.data)
+
+    def test_same_as_numpy(self):
+        unwrapped = unwrap_n(self.data, self.noise_size / 10, n=1)
+        np_unwrapped = np.unwrap(self.data, period=self.noise_size / 10)
+        assert np.allclose(unwrapped, np_unwrapped, rtol=1e-9)
+
+    def test_lengths(self):
+        # Check that an array of size 1 is unaffected
+        data = rng.uniform(size=1) * self.noise_size
+        unwrapped = unwrap_n(data, self.noise_size / 10, n=5)
+        assert np.array_equal(data, unwrapped)
+
+        # Check that an array shorter than the averaging length will not
+        # break anything. Also, check that a length-3 array is affected
+        # only when the chosen period is small enough.
+        data = rng.uniform(size=3) * self.noise_size
+        diff1 = abs(data[1] - data[0])
+        diff2 = abs(data[2] - (data[0] + data[1]) / 2)
+        max_diff = max(diff1, diff2)
+
+        period = max_diff * 1.99
+        unwrapped = unwrap_n(data, period, n=5)
+        assert len(unwrapped) == len(data)
+        assert not np.allclose(unwrapped, data, rtol=1e-9)
+
+        period = max_diff * 2.01
+        unwrapped = unwrap_n(data, period, n=5)
+        assert np.array_equal(unwrapped, data)


### PR DESCRIPTION
This adds Thomas Baker's algorithm to "correct" for flux jumps in detector baseline. The `correct_flux_jumps()` method on the channel and channel group has been around for many years, but used a poor algorithm by Dan Becker. Thomas's algorithm is much more reliable.

Nevertheless, the default is to use the original algorithm in case someone inadvertently depends on it.

You use the new algorithm by passing `algorithm=<any string other than "orig">` when calling `correct_flux_jumps()`. I typically use `algorithm="baker"`.