### PR TITLE
calibrateFollowingPlan was broken, fix it

### DIFF
--- a/tests/off/test_5lag_off.py
+++ b/tests/off/test_5lag_off.py
@@ -91,7 +91,7 @@ def test_off_5lag_with_saving_and_loading_recipes(tmp_path):
     assert all(data[3].pretriggerMeanCorrected == data2[3].pretriggerMeanCorrected)
     assert all(data[3].filtValue5LagDCPC == data2[3].filtValue5LagDCPC)
     assert all(data[3].cutResidualStdDev == data2[3].cutResidualStdDev)
-    assert data[3].recipes["energy"].f.uncalibratedName == data2[3].recipes["energy"].f.uncalibratedName
+    assert data[3].recipes["energy"].f.extra_info["uncalibratedName"] == data2[3].recipes["energy"].f.extra_info["uncalibratedName"]
     assert data[3].recipes["energy"].f.names == data2[3].recipes["energy"].f.names
 
     data3 = mass.off.ChannelGroup(off_filenames)

--- a/tests/off/test_channels.py
+++ b/tests/off/test_channels.py
@@ -106,6 +106,11 @@ class TestOFFTutorial:  # noqa PLR0904
         ds.linefit("W Ni-7", attr="energy", states=["W 1", "W 2"])
         ds.plotHist(np.arange(0, 4000, 4), "energy", coAddStates=False)
 
+        # the calibration from the plan should not be equal to the rough calibration
+        rough_cal = ds.recipes["energyRough"].f
+        filtValueDC_cal = ds.recipes["energy"].f
+        assert not np.allclose(rough_cal.ph, filtValueDC_cal.ph) # this fails in mass 0.8.5 due to bug introduced with energy cal refactor
+
         ds.diagnoseCalibration()
 
         data.calibrateFollowingPlan(

--- a/tests/off/test_off.py
+++ b/tests/off/test_off.py
@@ -2,7 +2,6 @@ import pytest
 import os
 import mass.off
 from mass.off import OffFile
-import resource
 
 d = os.path.dirname(os.path.realpath(__file__))
 
@@ -30,28 +29,3 @@ def test_open_file_with_base64_projectors_and_basis():
     assert OffFile(filename) is not None
 
 
-def test_mmap_many_files():
-    """Open more OFF file objects than the system allows. Test that close method closes them."""
-    files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
-
-    # LOWER the system's limit on number of open files, to make the test smaller
-    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    request_maxfiles = min(60, soft_limit)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
-    try:
-        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-        NFilesToOpen = maxfiles // 3 + 10
-
-        filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
-        for _ in range(NFilesToOpen):
-            f = OffFile(filename)
-            assert f.nRecords > 0
-            files.append(f)
-            f.close()
-
-    # Use the try...finally to ensure that the gc can close files at the end of this test,
-    # preventing a cascade of meaningless test failures if this one fails.
-    # Also undo our reduction in the limit on number of open files.
-    finally:
-        del files
-        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))

--- a/tests/off/test_too_many_files.py
+++ b/tests/off/test_too_many_files.py
@@ -1,5 +1,5 @@
 import resource
-from mass.off import util, ChannelGroup, getOffFileListFromOneFile, Channel, labelPeak, labelPeaks, NoCutInds
+from mass.off import util, ChannelGroup, getOffFileListFromOneFile, Channel, labelPeak, labelPeaks, NoCutInds, OffFile
 import os
 
 def test_open_many_OFF_files():
@@ -33,4 +33,30 @@ def test_open_many_OFF_files():
 
     # Use the try...finally to undo our reduction in the limit on number of open files.
     finally:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+
+def test_mmap_many_files():
+    """Open more OFF file objects than the system allows. Test that close method closes them."""
+    files = []  # hold on to the OffFile objects so the garbage collector doesn't close them.
+
+    # LOWER the system's limit on number of open files, to make the test smaller
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    request_maxfiles = min(60, soft_limit)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (request_maxfiles, hard_limit))
+    try:
+        maxfiles, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        NFilesToOpen = maxfiles // 3 + 10
+
+        filename = os.path.join(d, "data_for_test/off_with_binary_projectors_and_basis.off")
+        for _ in range(NFilesToOpen):
+            f = OffFile(filename)
+            assert f.nRecords > 0
+            files.append(f)
+            f.close()
+
+    # Use the try...finally to ensure that the gc can close files at the end of this test,
+    # preventing a cascade of meaningless test failures if this one fails.
+    # Also undo our reduction in the limit on number of open files.
+    finally:
+        del files
         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))


### PR DESCRIPTION
The `mass.off` method `calibrateFollowingPlan` was broken in the update to the new calibration api. I've fixed it, slightly changing the new calibration api in the process, and added a test.

I also noticed that `drop_one_errors` is now an api only on the calibration maker, it should be an api ALSO on the calibration. But I didn't change anything related to that.